### PR TITLE
Fix duplicated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ops >= 1.5.0
 kazoo >= 2.8.0
-pure-sasl >= 0.6.2
 tenacity >= 8.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -69,9 +69,7 @@ commands =
 description = Run unit tests
 deps =
     pytest
-    kazoo
     pure-sasl
-    tenacity
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
@@ -84,9 +82,7 @@ description = Run integration tests
 deps =
     pytest
     juju
-    kazoo
     pure-sasl
-    tenacity
     lightkube
     pytest-operator
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This fixes errors when executing tox automation tests. Requirements are already addded to one place (tox.ini or requirements.txt)