### PR TITLE
fix: ensure quorum not lost during tls relation + client ports update

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -129,7 +129,7 @@ class ZooKeeperK8sCharm(CharmBase):
         # check whether restart is needed for all `*_changed` events
         self.on[self.restart.name].acquire_lock.emit()
 
-        if self.tls.upgrading:
+        if self.tls.upgrading and len(self.cluster.peer_units) == 1:
             event.defer()
 
     def _restart(self, event: EventBase) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,6 +129,9 @@ class ZooKeeperK8sCharm(CharmBase):
         # check whether restart is needed for all `*_changed` events
         self.on[self.restart.name].acquire_lock.emit()
 
+        if self.tls.upgrading:
+            event.defer()
+
     def _restart(self, event: EventBase) -> None:
         """Handler for emitted restart events."""
         # this can cause issues if ran before `init_server()`
@@ -156,7 +159,11 @@ class ZooKeeperK8sCharm(CharmBase):
         # flag to update that this unit is running `portUnification` during ssl<->no-ssl upgrade
         # in case restart was manual, also remove
         self.cluster.relation.data[self.unit].update(
-            {"unified": "true" if self.tls.upgrading else "", "manual-restart": ""}
+            {
+                "unified": "true" if self.tls.upgrading else "",
+                "manual-restart": "",
+                "quorum": self.cluster.quorum or "",
+            }
         )
 
     def init_server(self):
@@ -199,7 +206,11 @@ class ZooKeeperK8sCharm(CharmBase):
         # flag to update that this unit is running `portUnification` during ssl<->no-ssl upgrade
         # added here in case a `restart` was missed
         self.cluster.relation.data[self.unit].update(
-            {"state": "started", "unified": "true" if self.tls.upgrading else ""}
+            {
+                "state": "started",
+                "unified": "true" if self.tls.upgrading else "",
+                "quorum": self.cluster.quorum or "",
+            }
         )
 
     def config_changed(self):
@@ -277,15 +288,27 @@ class ZooKeeperK8sCharm(CharmBase):
             # triggers a `cluster_relation_changed` to wake up following units
             self.cluster.relation.data[self.app].update(updated_servers)
 
+        # default startup without ssl relation
+        if not self.cluster.stale_quorum and not self.tls.enabled and not self.tls.upgrading:
+            if not self.cluster.quorum:  # avoids multiple loglines
+                logger.info("ZooKeeper cluster running with non-SSL quorum")
+
+            self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+
         # declare upgrade complete only when all peer units have started
         # triggers `cluster_relation_changed` to rolling-restart without `portUnification`
         if self.tls.all_units_unified:
             if self.tls.enabled:
-                logger.info("ZooKeeper cluster running with quorum encryption")
-                self.cluster.relation.data[self.app].update({"quorum": "ssl", "upgrading": ""})
+                self.cluster.relation.data[self.app].update({"quorum": "ssl"})
             else:
-                logger.info("ZooKeeper cluster running without quorum encryption")
-                self.cluster.relation.data[self.app].update({"quorum": "non-ssl", "upgrading": ""})
+                self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+
+            if self.cluster.all_units_quorum:
+                self.cluster.relation.data[self.app].update({"upgrading": ""})
+                logger.debug(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
+
+        # attempt update of client relation data in case port updated
+        self.provider.apply_relation_data(event)
 
     def add_init_leader(self) -> None:
         """Adds the first leader server to the relation data for other units to ack."""

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -315,7 +315,7 @@ class ZooKeeperCluster:
             UnitNotFoundError,
             BadArgumentsError,
         ) as e:
-            logger.debug(str(e))
+            logger.warning(str(e))
             return {}
 
     def is_unit_turn(self, unit: Optional[Unit] = None) -> bool:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -461,3 +461,21 @@ class ZooKeeperCluster:
             True if manual-restart flag is set. Otherwise False
         """
         return bool(self.relation.data[self.charm.app].get("manual-restart", None))
+
+    @property
+    def all_units_quorum(self) -> bool:
+        """Checks if all units are running with the cluster quorum encryption.
+
+        Returns:
+            True if all units are running the quorum encryption in app data.
+                Otherwise False.
+        """
+        unit_quorums = set()
+        for unit in self.peer_units:
+            unit_quorum = self.relation.data[unit].get("quorum", None)
+            if unit_quorum != self.quorum:
+                return False
+
+            unit_quorums.add(unit_quorum)
+
+        return len(unit_quorums) == 1

--- a/src/config.py
+++ b/src/config.py
@@ -261,7 +261,7 @@ class ZooKeeperConfig:
 
         Running ZooKeeper cluster with `reconfigEnabled` moves dynamic options
             to a dedicated dynamic file
-        These options are `dynamicConfigFile`, `clientPort` and `secureClientPort`
+        These options are `clientPort` and `secureClientPort`
 
         Args:
             properties: the properties to make static

--- a/src/tls.py
+++ b/src/tls.py
@@ -335,7 +335,7 @@ class ZooKeeperTLS(Object):
     def set_p12_keystore(self) -> None:
         """Creates and adds unit cert and private-key to a PCKS12 keystore."""
         try:
-            self.container.exec(
+            proc = self.container.exec(
                 [
                     "openssl",
                     "pkcs12",
@@ -355,8 +355,9 @@ class ZooKeeperTLS(Object):
                 ],
                 working_dir=self.charm.zookeeper_config.default_config_path,
             )
+            logger.debug(str(proc.wait_output()[1]))
         except ExecError as e:
-            logger.error(e.stdout)
+            logger.error(str(e.stdout))
             raise e
 
     def remove_stores(self) -> None:

--- a/src/tls.py
+++ b/src/tls.py
@@ -305,7 +305,7 @@ class ZooKeeperTLS(Object):
     def set_truststore(self) -> None:
         """Adds CA to JKS truststore."""
         try:
-            self.container.exec(
+            proc = self.container.exec(
                 [
                     "keytool",
                     "-import",
@@ -314,17 +314,21 @@ class ZooKeeperTLS(Object):
                     "ca",
                     "-file",
                     "ca.pem",
-                    "-keystore truststore.jks",
+                    "-keystore",
+                    "truststore.jks",
                     "-storepass",
                     f"{self.keystore_password}",
                     "-noprompt",
                 ],
                 working_dir=self.charm.zookeeper_config.default_config_path,
             )
+            logger.debug(str(proc.wait_output()[1]))
         except ExecError as e:
-            # in case this reruns and fails
-            if "already exists" in (str(e.stderr) or str(e.stdout)):
+            expected_error_string = "alias <ca> already exists"
+            if expected_error_string in str(e.stdout):
+                logger.debug(expected_error_string)
                 return
+
             logger.error(e.stdout)
             raise e
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -40,12 +39,11 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, "tls-certificates-operator"], status="active", timeout=1000
     )
-    time.sleep(10)
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications["tls-certificates-operator"].status == "active"
     await ops_test.model.add_relation(APP_NAME, "tls-certificates-operator")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, "tls-certificates-operator"], status="active", timeout=1000
+        apps=[APP_NAME, "tls-certificates-operator"], status="active", timeout=1000, idle_period=30
     )
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications["tls-certificates-operator"].status == "active"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, "tls-certificates-operator"], status="active", timeout=1000
     )
+    time.sleep(10)
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications["tls-certificates-operator"].status == "active"
     await ops_test.model.add_relation(APP_NAME, "tls-certificates-operator")
@@ -52,6 +54,9 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
 
     for unit in ops_test.model.applications[APP_NAME].units:
         assert "sslQuorum=true" in check_properties(
+            model_full_name=ops_test.model_full_name, unit=unit.name
+        )
+        assert "portUnification=true" not in check_properties(
             model_full_name=ops_test.model_full_name, unit=unit.name
         )
 
@@ -108,4 +113,17 @@ async def test_scale_up_tls(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].add_units(count=1)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 4)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    assert ping_servers(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_client_relate_maintains_quorum(ops_test: OpsTest):
+    dummy_name = "app"
+    app_charm = await ops_test.build_charm("tests/integration/app-charm")
+    await ops_test.model.deploy(app_charm, application_name=dummy_name, num_units=1)
+    await ops_test.model.wait_for_idle([APP_NAME, dummy_name], status="active", timeout=1000)
+    await ops_test.model.add_relation(APP_NAME, dummy_name)
+    await ops_test.model.wait_for_idle([APP_NAME, dummy_name], status="active", timeout=1000)
+    assert ops_test.model.applications[APP_NAME].status == "active"
+    assert ops_test.model.applications[dummy_name].status == "active"
     assert ping_servers(ops_test)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,9 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+from unittest.mock import patch
 
+import ops.testing
 import pytest
 import yaml
 from ops.testing import Harness
@@ -11,6 +13,15 @@ from ops.testing import Harness
 from charm import ZooKeeperK8sCharm
 from config import ZooKeeperConfig
 from literals import CHARM_KEY
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+
+
+@pytest.fixture(autouse=True)
+def patched_pull():
+    with patch("ops.model.Container.pull"):
+        yield
+
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
@@ -29,7 +40,6 @@ def test_build_static_properties_removes_necessary_rows():
         "clientPort=2181",
         "authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider",
         "maxClientCnxns=60",
-        "dynamicConfigFile=/data/zookeeper/zookeeper.properties.dynamic.100000041",
     ]
 
     static = ZooKeeperConfig.build_static_properties(properties=properties)

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest --ignore={[vars]tst_path}integration -vv --tb native -s {posargs}
     coverage report
 
 [testenv:integration]


### PR DESCRIPTION
## Changes Made
#### `fix: ensure quorum not lost during tls relations`
- Previous implementation mistakenly skipped the `portUnification`+`sslQuorum` step when switching to SSL quorum encryption, sometimes resulting in loss of quorum
    - This had a knock-on effect, where only a single-server quorum was left, and when a client related to the ZK app, that server would restart and not be part of a quorum 
    - Fixed by setting unit + app level relation data checking that all units are at the correct stage of an encryption change, before doing anything else
- Previous implementation mistakenly overwrote the dynamic property set in `zookeeper.properties` to set new SSL-specific config, sometimes resulting in loss of quorum
    - This resulted in servers sometimes not being aware of other server members after restarting, losing quorum  
    - Fixed by checking current `dynamicConfigPath` on the server, and appending it to `zookeeper.properties` during property update
#### `fix: remedy broken set_truststore method`
- `set_truststore` was non-functional on K8s due to a mistake in the command list having two commands in a single list item
    - This mistake was hidden in tests, as the previously mentioned loss of quorum meant that there was a single quorum member, and as such did not need the missing truststore anyway, hiding the bug
    - Fixed by splitting out the double-command in the arg list, and properly checking the command output