### PR TITLE
test: introduce charm.py unittest coverage

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -106,13 +106,13 @@ class ZooKeeperK8sCharm(CharmBase):
             event.defer()
             return
 
-        # If a password rotation is needed, or in progress
-        if not self.rotate_passwords():
-            return
-
         # not all methods called
         if not self.cluster.relation:
             self.unit.status = WaitingStatus("waiting for peer relation")
+            return
+
+        # If a password rotation is needed, or in progress
+        if not self.rotate_passwords():
             return
 
         # attempt startup of server
@@ -127,7 +127,7 @@ class ZooKeeperK8sCharm(CharmBase):
             return
 
         # check whether restart is needed for all `*_changed` events
-        self.on[self.restart.name].acquire_lock.emit()
+        self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         if self.tls.upgrading and len(self.cluster.peer_units) == 1:
             event.defer()
@@ -351,7 +351,7 @@ class ZooKeeperK8sCharm(CharmBase):
             if self.cluster.relation.data[self.unit].get("password-rotated"):
                 return False
 
-            self.on[self.restart.name].acquire_lock.emit()
+            self.on[f"{self.restart.name}"].acquire_lock.emit()
             return False
 
         else:

--- a/src/provider.py
+++ b/src/provider.py
@@ -308,7 +308,7 @@ class ZooKeeperProvider(Object):
                 return
 
         # All units restart after relation changed event to add new users
-        self.charm.on[self.charm.restart.name].acquire_lock.emit()
+        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
     def _on_client_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Removes user from ZK app data on `client_relation_broken`.

--- a/src/tls.py
+++ b/src/tls.py
@@ -210,7 +210,7 @@ class ZooKeeperTLS(Object):
         self.set_truststore()
         self.set_p12_keystore()
 
-        self.charm.on[self.charm.restart.name].acquire_lock.emit()
+        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
     def _on_certificates_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,8 +4,11 @@
 
 """General purpose helper functions for managing common charm functions."""
 
+import logging
 import secrets
 import string
+
+logger = logging.getLogger(__name__)
 
 from ops.model import Container
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import io
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import ops.testing
+import pytest
+import yaml
+from ops.framework import EventBase
+from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+from ops.testing import Harness
+
+from charm import ZooKeeperK8sCharm
+from literals import CHARM_KEY, CONTAINER, PEER
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperK8sCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
+    harness.set_can_connect(CONTAINER, True)
+    harness.begin()
+    return harness
+
+
+def test_install_fails_create_passwords_until_peer_relation(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+
+    harness.charm.on.install.emit()
+
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("sync-password", None)
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("super-password", None)
+
+
+def test_install_fails_creates_passwords_succeeds(harness):
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+    harness.charm.on.install.emit()
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("sync-password", None)
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("super-password", None)
+
+
+def test_relation_changed_emitted_for_leader_elected(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm._on_cluster_relation_changed") as patched:
+        harness.set_leader(True)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_config_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_changed.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_joined(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_joined.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_departed.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_waits_until_peer_relation(harness):
+    harness.charm.on.config_changed.emit()
+    assert isinstance(harness.model.unit.status, WaitingStatus)
+
+
+def test_relation_changed_stops_if_not_rotate_passwords(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"password-rotated": "true"})
+    with patch("charm.ZooKeeperK8sCharm.update_quorum") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_not_called()
+
+
+def test_relation_changed_starts_units(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm.init_server") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_does_not_start_units_again(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with patch("charm.ZooKeeperK8sCharm.init_server") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_not_called()
+
+
+def test_relation_changed_does_not_restart_on_departing(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        patched.assert_not_called()
+
+
+def test_relation_changed_updates_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm.update_quorum") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_restarts(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_defers_upgrading_single_unit(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
+    with patch("ops.framework.EventBase.defer") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_restart_fails_not_started(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperK8sCharm.config_changed") as patched:
+        harness.charm._restart(EventBase)
+        patched.assert_not_called()
+
+
+def test_restart_restarts_service_if_config_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with patch("ops.model.Container.restart") as patched, patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_service_if_manual(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"manual-restart": "true"})
+
+    with patch("ops.model.Container.restart") as patched, patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_service_sleeps(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep") as patched:
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_service_sets_active_status(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert isinstance(harness.model.unit.status, ActiveStatus)
+
+
+def test_restart_sets_password_rotated_on_unit(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
+
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("password-rotated", None)
+            == "true"
+        )
+
+
+def test_restart_sets_unified(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
+        )
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": ""})
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
+
+
+def test_restart_unsets_manual_restart(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(
+        peer_rel_id, f"{CHARM_KEY}/0", {"state": "started", "manual-restart": "true"}
+    )
+
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed"
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
+
+
+def test_restart_sets_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": "ssl"})
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": ""})
+    with patch("ops.model.Container.restart"), patch(
+        "charm.ZooKeeperK8sCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None)
+
+
+def test_init_server_maintenance_if_no_passwords(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    harness.charm.init_server()
+
+    assert isinstance(harness.charm.unit.status, MaintenanceStatus)
+
+
+def test_init_server_maintenance_if_not_turn(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(
+        peer_rel_id, CHARM_KEY, {"sync-password": "mellon", "super-password": "mellon"}
+    )
+
+    with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=False):
+        harness.charm.init_server()
+
+        assert isinstance(harness.charm.unit.status, MaintenanceStatus)
+
+
+def test_init_server_calls_necessary_methods(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"private-address": "gimli"})
+    harness.update_relation_data(
+        peer_rel_id,
+        CHARM_KEY,
+        {
+            "sync-password": "mellon",
+            "super-password": "mellon",
+            "upgrading": "started",
+            "quorum": "ssl",
+        },
+    )
+    with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True), patch(
+        "config.ZooKeeperConfig.set_zookeeper_myid"
+    ) as zookeeper_myid, patch("config.ZooKeeperConfig.set_kafka_opts") as kafka_opts, patch(
+        "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
+    ) as zookeeper_dynamic_properties, patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as zookeeper_properties, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as zookeeper_jaas_config, patch(
+        "ops.model.Container.replan"
+    ) as replan:
+        harness.charm.init_server()
+
+        zookeeper_myid.assert_called_once()
+        kafka_opts.assert_called_once()
+        zookeeper_dynamic_properties.assert_called_once()
+        zookeeper_properties.assert_called_once()
+        zookeeper_jaas_config.assert_called_once()
+        replan.assert_called_once()
+
+        assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
+        )
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("state", None) == "started"
+        )
+
+        assert isinstance(harness.charm.unit.status, ActiveStatus)
+
+
+def test_config_changed_updates_properties_and_jaas(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with patch("ops.model.Container.pull", return_value=io.StringIO("gandalf=grey")), patch(
+        "config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]
+    ), patch(
+        "config.ZooKeeperConfig.static_properties", new_callable=lambda: ["gandalf=grey"]
+    ), patch(
+        "config.ZooKeeperConfig.jaas_config", return_value="gandalf=grey"
+    ), patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as set_props, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as set_jaas:
+        harness.charm.config_changed()
+        set_props.assert_called_once()
+        set_jaas.assert_not_called()
+
+    with patch("ops.model.Container.pull", return_value=io.StringIO("gandalf=grey")), patch(
+        "config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]
+    ), patch(
+        "config.ZooKeeperConfig.static_properties", new_callable=lambda: ["gandalf=white"]
+    ), patch(
+        "config.ZooKeeperConfig.jaas_config", new_callable=lambda: "gandalf=white"
+    ), patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as set_props, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as set_jaas:
+        harness.charm.config_changed()
+        set_props.assert_not_called()
+        set_jaas.assert_called_once()
+
+
+def test_adding_units_updates_relation_data(harness):
+    with (patch("cluster.ZooKeeperCluster.update_cluster", return_value={"1": "added"})):
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/1", {"quorum": "ssl"})
+
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("1", None) == "added"
+
+
+def test_update_quorum_skips_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with patch("charm.ZooKeeperK8sCharm.add_init_leader") as patched_init_leader, patch(
+        "cluster.ZooKeeperCluster.update_cluster"
+    ) as patched_update_cluster:
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        patched_init_leader.assert_not_called()
+        patched_update_cluster.assert_not_called()
+
+
+def test_update_quorum_updates_cluster_for_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+    harness.set_leader(True)
+
+    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        patched_update_cluster.assert_called()
+
+
+def test_update_quorum_updates_cluster_for_leader_elected(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
+        harness.set_leader(True)
+        patched_update_cluster.assert_called()
+
+
+def test_update_quorum_adds_init_leader(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    with patch("charm.ZooKeeperK8sCharm.add_init_leader") as patched_init_leader:
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+        patched_init_leader.assert_called_once()
+
+
+def test_update_quorum_sets_non_ssl_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.set_leader(True)
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "non-ssl"
+
+
+def test_update_quorum_sets_ssl_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+    harness.set_leader(True)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_does_not_set_ssl_quorum_until_unified(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"unified": ""})
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_does_not_unset_upgrading_until_all_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "non-ssl"}
+        )
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"})
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_unsets_upgrading_when_all_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "ssl"}
+        )
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/1", {"quorum": "ssl"})
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"quorum": "ssl"})
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_config_changed_applies_relation_data(harness):
+    _ = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+
+    with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
+        harness.charm.on.config_changed.emit()
+
+        patched.assert_called_once()
+
+
+def test_init_leader_is_added(harness):
+    with patch("charm.ZooKeeperK8sCharm.config_changed", return_value=True), patch(
+        "ops.model.Container.restart"
+    ):
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.set_planned_units(2)
+
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("0", None) == "added"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,15 +2,20 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+from pathlib import Path
 from unittest.mock import call, patch
 
+import pytest
+import yaml
 from charms.zookeeper.v0.client import (
     MembersSyncingError,
     QuorumLeaderNotFoundError,
     ZooKeeperClient,
     ZooKeeperManager,
 )
+from kazoo.client import logging
+
+logger = logging.getLogger(__name__)
 
 
 class DummyClient:
@@ -51,65 +56,72 @@ class DummyClient:
         pass
 
 
-class TestClient(unittest.TestCase):
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    def test_config(self, client):
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+def test_config():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         client = ZooKeeperClient(host="", client_port=0, username="", password="")
         result, version = client.config
         servers = [server.split("=")[0] for server in result]
 
-        self.assertEqual(version, 4294967296)
-        self.assertIn("server.1", servers)
-        self.assertIn("server.2", servers)
+        assert version == 4294967296
+        assert "server.1" in servers
+        assert "server.2" in servers
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    def test_srvr(self, client):
+
+def test_srvr():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         client = ZooKeeperClient(host="", client_port=0, username="", password="")
         result = client.srvr
 
-        self.assertEqual(set(result.keys()), set(["Zookeeper version", "Outstanding", "Mode"]))
+        assert set(result.keys()) == set(["Zookeeper version", "Outstanding", "Mode"])
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    def test_mntr(self, client):
+
+def test_mntr():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         client = ZooKeeperClient(host="", client_port=0, username="", password="")
         result = client.mntr
 
-        self.assertEqual(
-            set(result.keys()),
-            set(["zk_pending_syncs", "zk_peer_state"]),
-        )
+        assert set(result.keys()) == set(["zk_pending_syncs", "zk_peer_state"])
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(ready=False))
-    def test_is_ready(self, client):
+
+def test_is_ready():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(ready=False)):
         client = ZooKeeperClient(host="", client_port=0, username="", password="")
-        self.assertFalse(client.is_ready)
+        assert not client.is_ready
 
 
-class TestManager(unittest.TestCase):
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(follower=True))
-    def test_init_raises_if_leader_not_found(self, _):
-        with self.assertRaises(QuorumLeaderNotFoundError):
+def test_init_raises_if_leader_not_found():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(follower=True)):
+        with pytest.raises(QuorumLeaderNotFoundError):
             ZooKeeperManager(hosts=["host"], username="", password="")
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    def test_init_finds_leader(self, _):
-        zk = ZooKeeperManager(hosts=["host"], username="", password="")
-        self.assertEqual(zk.leader, "host")
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True))
-    def test_members_syncing(self, _):
+def test_init_finds_leader():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         zk = ZooKeeperManager(hosts=["host"], username="", password="")
-        self.assertTrue(zk.members_syncing)
+        assert zk.leader == "host"
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True))
-    def test_add_members_raises(self, _):
+
+def test_members_syncing():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True)):
         zk = ZooKeeperManager(hosts=["host"], username="", password="")
-        with self.assertRaises(MembersSyncingError):
+        assert zk.members_syncing
+
+
+def test_add_members_raises():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True)):
+        zk = ZooKeeperManager(hosts=["host"], username="", password="")
+        with pytest.raises(MembersSyncingError):
             zk.add_members(["server.1=bilbo.baggins"])
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    @patch.object(DummyClient, "reconfig")
-    def test_add_members_correct_args(self, reconfig, _):
+
+@patch.object(DummyClient, "reconfig")
+def test_add_members_correct_args(reconfig):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         zk = ZooKeeperManager(hosts=["server.1=bilbo.baggins"], username="", password="")
         zk.add_members(["server.2=sam.gamgee"])
 
@@ -117,9 +129,10 @@ class TestManager(unittest.TestCase):
             joining="server.2=sam.gamgee", leaving=None, new_members=None, from_config=4294967296
         )
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    @patch.object(DummyClient, "reconfig")
-    def test_add_members_runs_on_leader(self, _, client):
+
+@patch.object(DummyClient, "reconfig")
+def test_add_members_runs_on_leader(_):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()) as client:
         zk = ZooKeeperManager(hosts=["server.1=bilbo.baggins"], username="", password="")
         zk.leader = "leader"
         zk.add_members(["server.2=sam.gamgee"])
@@ -136,17 +149,20 @@ class TestManager(unittest.TestCase):
                 verify_certs=False,
                 use_ssl=False,
             )
-        ) in calls
+            in calls
+        )
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True))
-    def test_remove_members_raises(self, _):
+
+def test_remove_members_raises():
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient(syncing=True)):
         zk = ZooKeeperManager(hosts=["host"], username="", password="")
-        with self.assertRaises(MembersSyncingError):
+        with pytest.raises(MembersSyncingError):
             zk.remove_members(["server.1=bilbo.baggins"])
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    @patch.object(DummyClient, "reconfig")
-    def test_remove_members_correct_args(self, reconfig, _):
+
+@patch.object(DummyClient, "reconfig")
+def test_remove_members_correct_args(reconfig):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         zk = ZooKeeperManager(hosts=["server.1=bilbo.baggins"], username="", password="")
         zk.remove_members(["server.2=sam.gamgee"])
 
@@ -154,9 +170,10 @@ class TestManager(unittest.TestCase):
             joining=None, leaving="2", new_members=None, from_config=4294967296
         )
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    @patch.object(DummyClient, "reconfig")
-    def test_remove_members_handles_zeroes(self, reconfig, _):
+
+@patch.object(DummyClient, "reconfig")
+def test_remove_members_handles_zeroes(reconfig):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
         zk = ZooKeeperManager(
             hosts=[
                 "server.1=bilbo.baggins",
@@ -175,9 +192,10 @@ class TestManager(unittest.TestCase):
             joining=None, leaving="300", new_members=None, from_config=4294967296
         )
 
-    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
-    @patch.object(DummyClient, "reconfig")
-    def test_remove_members_runs_on_leader(self, _, client):
+
+@patch.object(DummyClient, "reconfig")
+def test_remove_members_runs_on_leader(_):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()) as client:
         zk = ZooKeeperManager(hosts=["server.1=bilbo.baggins"], username="", password="")
         zk.leader = "leader"
         zk.remove_members(["server.2=sam.gamgee"])
@@ -194,4 +212,5 @@ class TestManager(unittest.TestCase):
                 verify_certs=False,
                 use_ssl=False,
             )
-        ) in calls
+            in calls
+        )

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2,213 +2,391 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import re
-import unittest
+from pathlib import Path
 
-import ops.testing
-from ops.charm import CharmBase
+import pytest
+import yaml
 from ops.model import Unit
 from ops.testing import Harness
 
-from cluster import UnitNotFoundError, ZooKeeperCluster
+from charm import ZooKeeperK8sCharm
+from cluster import UnitNotFoundError
+from literals import CHARM_KEY, PEER
 
-ops.testing.SIMULATE_CAN_CONNECT = True
+logger = logging.getLogger(__name__)
 
-
-METADATA = """
-    name: zookeeper
-    peers:
-        cluster:
-            interface: cluster
-"""
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 
-class DummyZooKeeperCharm(CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.cluster = ZooKeeperCluster(self)
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperK8sCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation("restart", CHARM_KEY)
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
+    harness.begin()
+    return harness
 
 
-class TestCluster(unittest.TestCase):
-    def setUp(self):
-        self.harness = Harness(DummyZooKeeperCharm, meta=METADATA)
-        self.addCleanup(self.harness.cleanup)
-        self.relation_id = self.harness.add_relation("cluster", "cluster")
-        self.harness.begin_with_initial_hooks()
+def test_peer_units_contains_unit(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    assert len(harness.charm.cluster.peer_units) == 2
 
-    @property
-    def cluster(self):
-        return self.harness.charm.cluster
 
-    def test_peer_units_contains_unit(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
+def test_started_units_ignores_ready_units(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"state": "started"}
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/3", {"state": "started"}
+    )
 
-        self.assertEqual(len(self.cluster.peer_units), 2)
+    assert len(harness.charm.cluster.started_units) == 2
 
-    def test_started_units_ignores_ready_units(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/1", {"state": "ready"})
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/2", {"state": "started"})
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/3", {"state": "started"})
 
-        self.assertEqual(len(self.cluster.started_units), 2)
+def test_get_unit_id(harness):
+    assert harness.charm.cluster.get_unit_id(harness.charm.unit) == 0
 
-    def test_get_unit_id(self):
-        self.assertEqual(self.harness.charm.cluster.get_unit_id(self.harness.charm.unit), 0)
 
-    def test_get_unit_from_id_succeeds(self):
-        unit = self.cluster.get_unit_from_id(0)
+def test_get_unit_from_id_succeeds(harness):
+    unit = harness.charm.cluster.get_unit_from_id(0)
 
-        self.assertTrue(isinstance(unit, Unit))
+    assert isinstance(unit, Unit)
 
-    def test_get_unit_from_id_raises(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
 
-        with self.assertRaises(UnitNotFoundError):
-            self.cluster.get_unit_from_id(100)
+def test_get_unit_from_id_raises(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
-    def test_unit_config_raises_for_missing_unit(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.get_unit_from_id(100)
 
-        with self.assertRaises(UnitNotFoundError):
-            self.cluster.get_unit_from_id(100)
 
-    def test_unit_config_succeeds_for_id(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.cluster.unit_config(unit=1)
+def test_unit_config_raises_for_missing_unit(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
-    def test_unit_config_succeeds_for_unit(self):
-        self.cluster.unit_config(self.harness.charm.unit)
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.get_unit_from_id(100)
 
-    def test_unit_config_has_all_keys(self):
-        config = self.cluster.unit_config(0)
 
-        self.assertEqual(
-            set(config.keys()),
-            set(["host", "server_string", "server_id", "unit_id", "unit_name", "state"]),
-        )
+def test_unit_config_succeeds_for_id(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    assert harness.charm.cluster.unit_config(unit=1)
 
-    def test_unit_config_server_string_format(self):
-        server_string = self.cluster.unit_config(0)["server_string"]
-        split_string = re.split("=|:|;", server_string)
 
-        self.assertEqual(len(split_string), 7)
+def test_unit_config_succeeds_for_unit(harness):
+    assert harness.charm.cluster.unit_config(harness.charm.unit)
 
-    def test_get_updated_servers(self):
-        added_servers = [
-            "server.2=gandalf.the.grey",
-        ]
-        removed_servers = [
-            "server.2=gandalf.the.grey",
-            "server.3=in.a.hole.in.the.ground.there.lived.a:hobbit",
-        ]
-        updated_servers = self.cluster._get_updated_servers(
-            added_servers=added_servers, removed_servers=removed_servers
-        )
 
-        self.assertDictEqual(updated_servers, {"2": "removed", "1": "added"})
+def test_unit_config_has_all_keys(harness):
+    config = harness.charm.cluster.unit_config(0)
 
-    def test_is_unit_turn_succeeds_scaleup(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "added", "2": "added"}
-        )
+    assert set(config.keys()) == set(
+        ["host", "server_string", "server_id", "unit_id", "unit_name", "state"]
+    )
 
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(1)
-        self.assertTrue(self.cluster.is_unit_turn(units[0]))
 
-    def test_is_unit_turn_fails_scaleup(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
+def test_unit_config_server_string_format(harness):
+    server_string = harness.charm.cluster.unit_config(0)["server_string"]
+    split_string = re.split("=|:|;", server_string)
 
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
+    assert len(split_string) == 7
+    assert f"{CHARM_KEY}-0.zookeeper-k8s-endpoints" in split_string
 
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
 
-    def test_is_unit_turn_succeeds_failover(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
+def test_get_updated_servers(harness):
+    added_servers = [
+        "server.2=gandalf.the.grey",
+    ]
+    removed_servers = [
+        "server.2=gandalf.the.grey",
+        "server.3=in.a.hole.in.the.ground.there.lived.a:hobbit",
+    ]
+    updated_servers = harness.charm.cluster._get_updated_servers(
+        added_servers=added_servers, removed_servers=removed_servers
+    )
 
-        self.assertTrue(self.cluster.is_unit_turn(units[0]))
-        self.assertTrue(self.cluster.is_unit_turn(units[2]))
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
+    assert updated_servers == {"2": "removed", "1": "added"}
 
-    def test_is_unit_turn_fails_failover(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
 
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
+def test_is_unit_turn_succeeds_scaleup(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "2": "added"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(1)
+    assert harness.charm.cluster.is_unit_turn(units[0])
 
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
 
-    def test_generate_units_scaleup_adds_all_servers(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "added"}
-        )
+def test_is_unit_turn_fails_scaleup(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        new_unit_string = self.cluster.unit_config(2, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-        self.assertIn("server.3=zookeeper-2", generated_servers)
-        self.assertEqual(len(generated_servers.splitlines()), 4)
 
-    def test_generate_units_scaleup_adds_correct_roles_for_added_units(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "removed"}
-        )
+def test_is_unit_turn_succeeds_failover(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        new_unit_string = self.cluster.unit_config(2, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+    assert harness.charm.cluster.is_unit_turn(units[0])
+    assert harness.charm.cluster.is_unit_turn(units[2])
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-        self.assertEqual(len(re.findall("participant", generated_servers)), 1)
-        self.assertEqual(len(re.findall("observer", generated_servers)), 1)
 
-    def test_generate_units_failover(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "removed", "1": "added", "2": "removed"}
-        )
+def test_is_unit_turn_fails_failover(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        new_unit_string = self.cluster.unit_config(0, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-        self.assertEqual(len(generated_servers.splitlines()), 3)
+
+def test_generate_units_scaleup_adds_all_servers(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
+    )
+
+    new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+
+    assert (
+        f"server.3={CHARM_KEY}-2.zookeeper-k8s-endpoints:2888:3888:observer;0.0.0.0:2181"
+        in generated_servers
+    )
+    assert len(generated_servers.splitlines()) == 4
+
+
+def test_generate_units_scaleup_adds_correct_roles_for_added_units(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
+    )
+
+    new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+
+    assert len(re.findall("participant", generated_servers)) == 1
+    assert len(re.findall("observer", generated_servers)) == 1
+
+
+def test_generate_units_failover(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "1": "added", "2": "removed"},
+    )
+
+    new_unit_string = harness.charm.cluster.unit_config(0, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+
+    assert len(generated_servers.splitlines()) == 3
+
+
+def test_startup_servers_raises_for_missing_data(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "sync_password": "Mellon"},
+    )
+
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.startup_servers(unit=3)
+
+
+def test_startup_servers_succeeds_init(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.set_planned_units(1)
+    servers = harness.charm.cluster.startup_servers(unit=0)
+    assert "observer" not in servers
+
+
+def test_startup_servers_succeeds_failover_after_init(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "1": "added", "sync_password": "Mellon"},
+    )
+
+    generated_servers = harness.charm.cluster.startup_servers(unit=0)
+
+    assert len(re.findall("participant", generated_servers)) == 1
+    assert len(re.findall("observer", generated_servers)) == 1
+
+
+def test_all_units_related(harness):
+    assert not harness.charm.cluster.all_units_related
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.set_planned_units(2)
+    assert harness.charm.cluster.all_units_related
+
+
+def test_lowest_unit_id_none_if_not_all_related(harness):
+    assert harness.charm.cluster.lowest_unit_id == None  # noqa: E711
+
+
+def test_lowest_unit_id(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.set_planned_units(2)
+    assert harness.charm.cluster.lowest_unit_id == 0
+
+
+def test_stale_quorum_not_all_related(harness):
+    assert not harness.charm.cluster.stale_quorum
+
+
+def test_stale_quorum_unit_departed(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "removed"}
+    )
+    assert not harness.charm.cluster.stale_quorum
+
+
+def test_stale_quorum_new_unit(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.set_planned_units(2)
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": ""}
+    )
+
+    assert harness.charm.cluster.stale_quorum
+
+
+def test_stale_quorum_all_added(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.set_planned_units(2)
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "added"}
+    )
+    assert not harness.charm.cluster.stale_quorum
+
+
+def test_all_rotated_fails(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+    )
+    assert not harness.charm.cluster._all_rotated()
+
+
+def test_all_rotated_succeeds(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"password-rotated": "true"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+    )
+
+    assert harness.charm.cluster._all_rotated()
+
+
+def test_passwords_set_fails_missing_unit_passwords(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}/0",
+        {"super-password": "mellon", "sync-password": "mellon"},
+    )
+    assert not harness.charm.cluster.passwords_set
+
+
+def test_passwords_set_fails_missing_password(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"super-password": "mellon"}
+    )
+    assert not harness.charm.cluster.passwords_set
+
+
+def test_passwords_set_succeeds(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}/0",
+        {"super-password": "mellon", "sync-password": "mellon"},
+    )
+    assert not harness.charm.cluster.passwords_set
+
+
+def test_all_units_quorum_fails_wrong_quorum(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
+    )
+
+    assert not harness.charm.cluster.all_units_quorum
+
+    harness.update_relation_data(harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"})
+
+    assert not harness.charm.cluster.all_units_quorum
+
+
+def test_all_units_quorum_succeeds(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"})
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
+    )
+
+    assert harness.charm.cluster.all_units_quorum

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -4,356 +4,352 @@
 
 import logging
 import re
-import unittest
 from collections import namedtuple
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 from ops.charm import RelationBrokenEvent
 from ops.testing import Harness
 
 from charm import ZooKeeperK8sCharm
-from literals import CHARM_KEY, PEER, REL_NAME
+from literals import CHARM_KEY, CONTAINER, PEER, REL_NAME
 
 logger = logging.getLogger(__name__)
 
-METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 CustomRelation = namedtuple("Relation", ["id"])
 
 
-class TestProvider(unittest.TestCase):
-    def setUp(self):
-        self.harness = Harness(ZooKeeperK8sCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
-        self.addCleanup(self.harness.cleanup)
-        self.client_rel_id = self.harness.add_relation(REL_NAME, "application")
-        self.peer_rel_id = self.harness.add_relation(PEER, CHARM_KEY)
-        self.harness.begin()
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperK8sCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation(REL_NAME, "application")
+    peer_rel_id = harness.add_relation("restart", CHARM_KEY)
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_can_connect(CONTAINER, True)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
+    harness.begin()
+    return harness
 
-    @property
-    def provider(self):
-        return self.harness.charm.provider
 
-    def test_relation_config_new_relation_no_chroot(self):
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
+def test_relation_config_new_relation_no_chroot(harness):
+    with harness.hooks_disabled():
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
         )
-        self.assertIsNone(config)
+    assert not config
 
-    def test_relation_config_new_relation(self):
 
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+def test_relation_config_new_relation(harness):
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
-        self.harness.update_relation_data(
-            self.provider.app_relation.id, CHARM_KEY, {"relation-0": "password"}
-        )
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
-        )
-
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "password",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"relation-0": "password"}
         )
 
-    def test_relation_config_new_relation_defaults_to_database(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"database": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.app_relation.id, CHARM_KEY, {"relation-0": "password"}
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
         )
 
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
+    assert config == {
+        "username": "relation-0",
+        "password": "password",
+        "chroot": "/app",
+        "acl": "cdrwa",
+    }
+
+
+def test_relation_config_new_relation_defaults_to_database(harness):
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"database": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"relation-0": "password"}
         )
 
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "password",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
         )
 
-    def test_relation_config_new_relation_empty_password(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        assert config == {
+            "username": "relation-0",
+            "password": "password",
+            "chroot": "/app",
+            "acl": "cdrwa",
+        }
+
+
+def test_relation_config_new_relation_empty_password(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0]
+    )
+
+    assert config == {
+        "username": "relation-0",
+        "password": "",
+        "chroot": "/app",
+        "acl": "cdrwa",
+    }
+
+
+def test_relation_config_new_relation_app_permissions(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id,
+        "application",
+        {"chroot": "app", "chroot-acl": "rw"},
+    )
+
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0]
+    )
+
+    assert config == {
+        "username": "relation-0",
+        "password": "",
+        "chroot": "/app",
+        "acl": "rw",
+    }
+
+
+def test_relation_config_new_relation_skips_relation_broken(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id,
+        "application",
+        {"chroot": "app", "chroot-acl": "rw"},
+    )
+
+    custom_relation = CustomRelation(id=harness.charm.provider.client_relations[0].id)
+
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0],
+        event=RelationBrokenEvent(handle="", relation=custom_relation),
+    )
+
+    assert not config
+
+
+def test_relations_config_multiple_relations(harness):
+    harness.add_relation(REL_NAME, "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id, "new_application", {"chroot": "new_app"}
+    )
+
+    relations_config = harness.charm.provider.relations_config()
+
+    assert relations_config == {
+        "0": {
+            "username": "relation-0",
+            "password": "",
+            "chroot": "/app",
+            "acl": "cdrwa",
+        },
+        "3": {
+            "username": "relation-3",
+            "password": "",
+            "chroot": "/new_app",
+            "acl": "cdrwa",
+        },
+    }
+
+
+def test_build_acls(harness):
+    harness.add_relation(REL_NAME, "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id,
+        "new_application",
+        {"chroot": "new_app", "chroot-acl": "rw"},
+    )
+
+    acls = harness.charm.provider.build_acls()
+
+    assert len(acls) == 2
+    assert sorted(acls.keys()) == ["/app", "/new_app"]
+    assert isinstance(acls["/app"], list)
+
+    new_app_acl = acls["/new_app"][0]
+
+    assert new_app_acl.acl_list == ["READ", "WRITE"]
+    assert new_app_acl.id.scheme == "sasl"
+    assert new_app_acl.id.id == "relation-3"
+
+
+def test_relations_config_values_for_key(harness):
+    harness.add_relation(REL_NAME, "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id,
+        "new_application",
+        {"chroot": "new_app", "chroot-acl": "rw"},
+    )
+
+    config_values = harness.charm.provider.relations_config_values_for_key(key="username")
+
+    assert config_values == {"relation-3", "relation-0"}
+
+
+def test_is_child_of(harness):
+    chroot = "/gandalf/the/white"
+    chroots = {"/gandalf", "/saruman"}
+
+    assert harness.charm.provider._is_child_of(path=chroot, chroots=chroots)
+
+
+def test_is_child_of_not(harness):
+    chroot = "/the/one/ring"
+    chroots = {"/gandalf", "/saruman"}
+
+    assert not harness.charm.provider._is_child_of(path=chroot, chroots=chroots)
+
+
+def test_port_updates_if_tls(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
 
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
-        )
-
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
-        )
-
-    def test_relation_config_new_relation_app_permissions(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id,
-            "application",
-            {"chroot": "app", "chroot-acl": "rw"},
-        )
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
-        )
-
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "",
-                "chroot": "/app",
-                "acl": "rw",
-            },
-        )
-
-    def test_relation_config_new_relation_skips_relation_broken(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id,
-            "application",
-            {"chroot": "app", "chroot-acl": "rw"},
-        )
-
-        custom_relation = CustomRelation(id=self.provider.client_relations[0].id)
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0],
-            event=RelationBrokenEvent(handle="", relation=custom_relation),
-        )
-
-        self.assertIsNone(config)
-
-    def test_relations_config_multiple_relations(self):
-        self.harness.add_relation(REL_NAME, "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id, "new_application", {"chroot": "new_app"}
-        )
-
-        relations_config = self.harness.charm.provider.relations_config()
-
-        self.assertEqual(
-            relations_config,
-            {
-                "0": {
-                    "username": "relation-0",
-                    "password": "",
-                    "chroot": "/app",
-                    "acl": "cdrwa",
-                },
-                "2": {
-                    "username": "relation-2",
-                    "password": "",
-                    "chroot": "/new_app",
-                    "acl": "cdrwa",
-                },
-            },
-        )
-
-    def test_build_acls(self):
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id,
-            "new_application",
-            {"chroot": "new_app", "chroot-acl": "rw"},
-        )
-
-        acls = self.harness.charm.provider.build_acls()
-
-        self.assertEqual(len(acls), 2)
-        self.assertEqual(sorted(acls.keys()), ["/app", "/new_app"])
-        self.assertIsInstance(acls["/app"], list)
-
-        new_app_acl = acls["/new_app"][0]
-
-        self.assertEqual(new_app_acl.acl_list, ["READ", "WRITE"])
-        self.assertEqual(new_app_acl.id.scheme, "sasl")
-        self.assertEqual(new_app_acl.id.id, "relation-2")
-
-    def test_relations_config_values_for_key(self):
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id,
-            "new_application",
-            {"chroot": "new_app", "chroot-acl": "rw"},
-        )
-
-        config_values = self.harness.charm.provider.relations_config_values_for_key(key="username")
-
-        self.assertEqual(config_values, {"relation-2", "relation-0"})
-
-    def test_is_child_of(self):
-        chroot = "/gandalf/the/white"
-        chroots = {"/gandalf", "/saruman"}
-
-        self.assertTrue(self.harness.charm.provider._is_child_of(path=chroot, chroots=chroots))
-
-    def test_is_child_of_not(self):
-        chroot = "/the/one/ring"
-        chroots = {"/gandalf", "/saruman"}
-
-        self.assertFalse(self.harness.charm.provider._is_child_of(path=chroot, chroots=chroots))
-
-    def test_port_updates_if_tls(self):
-        self.harness.set_leader(True)
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
         # checking if ssl port and ssl flag are passed
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             f"{CHARM_KEY}/0",
-            {"state": "started"},
+            {"private-address": "treebeard", "state": "started"},
         )
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             CHARM_KEY,
             {"quorum": "ssl"},
         )
-        self.harness.charm.provider.apply_relation_data()
+        harness.charm.provider.apply_relation_data()
 
-        for relation in self.provider.client_relations:
-            uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("tls", "")
+    for relation in harness.charm.provider.client_relations:
+        uris = relation.data[harness.charm.app].get("uris", "")
+        ssl = relation.data[harness.charm.app].get("tls", "")
 
-            self.assertIn(str(self.harness.charm.cluster.secure_client_port), uris)
-            self.assertEqual(ssl, "enabled")
+        assert str(harness.charm.cluster.secure_client_port) in uris
+        assert ssl == "enabled"
 
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+    with harness.hooks_disabled():
+        # checking if normal port and non-ssl flag are passed
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}/0",
+            {"private-address": "treebeard", "state": "started", "quorum": "non-ssl"},
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             CHARM_KEY,
             {"quorum": "non-ssl"},
         )
-        self.harness.charm.provider.apply_relation_data()
+        harness.charm.provider.apply_relation_data()
 
-        for relation in self.provider.client_relations:
-            uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("tls", "")
+    for relation in harness.charm.provider.client_relations:
+        uris = relation.data[harness.charm.app].get("uris", "")
+        ssl = relation.data[harness.charm.app].get("tls", "")
 
-            self.assertIn(str(self.harness.charm.cluster.client_port), uris)
-            self.assertEqual(ssl, "disabled")
+        assert str(harness.charm.cluster.client_port) in uris
+        assert ssl == "disabled"
 
-    @patch("ops.model.Container.can_connect")
-    @patch(
-        "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", return_value=None
-    )
-    def test_provider_relation_data_updates_port(self, *_):
-        with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
-            self.harness.set_leader(True)
-            self.harness.update_relation_data(
-                self.peer_rel_id,
-                CHARM_KEY,
-                {"quorum": "non-ssl"},
-            )
 
-            patched.assert_called_once()
-
-    def test_apply_relation_data(self):
-        self.harness.set_leader(True)
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+def test_provider_relation_data_updates_port(harness):
+    with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
+        harness.set_leader(True)
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            CHARM_KEY,
+            {"quorum": "non-ssl"},
         )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id,
+
+        patched.assert_called_once()
+
+
+def test_apply_relation_data(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        harness.add_relation(REL_NAME, "new_application")
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[1].id,
             "new_application",
             {"chroot": "new_app", "chroot-acl": "rw"},
         )
-        self.harness.add_relation_unit(self.provider.app_relation.id, f"{CHARM_KEY}/0")
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             f"{CHARM_KEY}/0",
-            {"state": "started"},
+            {"private-address": "treebeard", "state": "started"},
         )
-        self.harness.add_relation_unit(self.provider.app_relation.id, f"{CHARM_KEY}/1")
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             f"{CHARM_KEY}/1",
-            {"state": "ready"},
+            {"private-address": "shelob", "state": "ready"},
         )
-        self.harness.add_relation_unit(self.provider.app_relation.id, f"{CHARM_KEY}/2")
-        self.harness.update_relation_data(
-            self.provider.app_relation.id,
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
             f"{CHARM_KEY}/2",
-            {"state": "started"},
+            {"private-address": "balrog", "state": "started"},
         )
 
-        self.harness.charm.provider.apply_relation_data()
+    harness.charm.provider.apply_relation_data()
 
-        self.assertIsNotNone(
-            self.harness.charm.cluster.relation.data[self.harness.charm.app].get(
-                "relation-0", None
-            )
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-0", None)
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-3", None)
+
+    app_data = harness.charm.cluster.relation.data[harness.charm.app]
+    passwords = []
+    usernames = []
+    for relation in harness.charm.provider.client_relations:
+        # checking existence of all necessary keys
+
+        assert sorted(relation.data[harness.charm.app].keys()) == sorted(
+            ["chroot", "endpoints", "password", "tls", "uris", "username"]
         )
-        self.assertIsNotNone(
-            self.harness.charm.cluster.relation.data[self.harness.charm.app].get(
-                "relation-2", None
-            )
+
+        username = relation.data[harness.charm.app]["username"]
+        password = relation.data[harness.charm.app]["password"]
+
+        # checking ZK app data got updated
+        assert username in app_data
+        assert password == app_data.get(username, None)
+
+        # checking unique passwords and usernames for all relations
+        assert username not in usernames
+        assert password not in passwords
+
+        # checking multiple endpoints and uris
+        assert len(relation.data[harness.charm.app]["endpoints"].split(",")) == 2
+        assert len(relation.data[harness.charm.app]["uris"].split(",")) == 2
+
+        for uri in relation.data[harness.charm.app]["uris"].split(","):
+            # checking client_port in uri
+            assert re.search(r":[\d]+", uri)
+
+        assert relation.data[harness.charm.app]["uris"].endswith(
+            relation.data[harness.charm.app]["chroot"]
         )
 
-        app_data = self.harness.charm.cluster.relation.data[self.harness.charm.app]
-        passwords = []
-        usernames = []
-        for relation in self.provider.client_relations:
-            # checking existence of all necessary keys
-            self.assertEqual(
-                sorted(relation.data[self.harness.charm.app].keys()),
-                sorted(["chroot", "endpoints", "password", "tls", "uris", "username"]),
-            )
-
-            username = relation.data[self.harness.charm.app]["username"]
-            password = relation.data[self.harness.charm.app]["password"]
-
-            # checking ZK app data got updated
-            self.assertIn(username, app_data)
-            self.assertEqual(password, app_data.get(username, None))
-
-            # checking unique passwords and usernames for all relations
-            self.assertNotIn(username, usernames)
-            self.assertNotIn(password, passwords)
-
-            # checking multiple endpoints and uris
-            self.assertEqual(len(relation.data[self.harness.charm.app]["endpoints"].split(",")), 2)
-            self.assertEqual(len(relation.data[self.harness.charm.app]["uris"].split(",")), 2)
-
-            for uri in relation.data[self.harness.charm.app]["uris"].split(","):
-                # checking client_port in uri
-                self.assertTrue(re.search(r":[\d]+", uri))
-
-            self.assertTrue(
-                relation.data[self.harness.charm.app]["uris"].endswith(
-                    relation.data[self.harness.charm.app]["chroot"]
-                )
-            )
-
-            passwords.append(username)
-            usernames.append(password)
+        passwords.append(username)
+        usernames.append(password)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -17,7 +17,7 @@ ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def harness():
     harness = Harness(ZooKeeperK8sCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)


### PR DESCRIPTION
## Changes Made
#### `test: introduce charm.py and cluster.py unittest coverage`
- Due to active development, there were no unittests for `charm.py`. These have been added
- Added additional `cluster.py` and `tls.py` tests to add coverage for new features
#### `style: misc linting/typeerror fixes`

## Review Notes
- Please focus on `tests/unit/test_charm.py`
- There are a lot of tests, so most help would be whether any were implemented incorrectly from an `ops.testing` standpoint