### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
 
   integration-test-password-rotation:
     name: Integration tests for password-rotation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +45,9 @@ jobs:
 
   integration-test-provider:
     name: Integration tests for provider (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,6 +63,9 @@ jobs:
 
   integration-test-scaling:
     name: Integration tests for scaling (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -72,6 +81,9 @@ jobs:
 
   integration-test-tls:
     name: Integration tests for tls (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,10 @@ jobs:
 
   integration-test-password-rotation:
     name: Integration tests for password-rotation (microk8s)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,6 +64,10 @@ jobs:
 
   integration-test-provider:
     name: Integration tests for provider (microk8s)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -75,6 +83,10 @@ jobs:
 
   integration-test-scaling:
     name: Integration tests for scaling (microk8s)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -90,6 +102,10 @@ jobs:
 
   integration-test-tls:
     name: Integration tests for tls (microk8s)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.