### PR TITLE
refactor: use new charmed-zookeeper image and layout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,18 +3,6 @@
 # See LICENSE file for licensing details.
 
 options:
-  conf-dir:
-    description: filepath for setting the ZooKeeper conf directory
-    type: string
-    default: "/opt/zookeeper/conf"
-  data-dir:
-    description: filepath for setting the ZooKeeper dataDir option
-    type: string
-    default: "/opt/zookeeper"
-  log-dir: 
-    description: filepath for setting the ZooKeeper dataLogDir option
-    type: string
-    default: "/logs/zookeeper"
   tick-time: 
     description: length of a single tick, in milliseconds, that ZooKeeper uses as the basic time unit to regulate timeouts
     type: int

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   zookeeper-image:
     type: oci-image
     description: OCI Image for Apache ZooKeeper
-    upstream-source: gchr.io/canonical/charmed-zookeeper:3.6.4-22.04_edge
+    upstream-source: gchr.io/canonical/charmed-zookeeper:3-edge
 
 peers:
   cluster:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   zookeeper-image:
     type: oci-image
     description: OCI Image for Apache ZooKeeper
-    upstream-source: gchr.io/canonical/charmed-zookeeper:3-edge
+    upstream-source: ghcr.io/canonical/charmed-zookeeper:3-edge
 
 peers:
   cluster:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   zookeeper-image:
     type: oci-image
     description: OCI Image for Apache ZooKeeper
-    upstream-source: dataplatformoci/zookeeper:3.6.4
+    upstream-source: gchr.io/canonical/charmed-zookeeper:3.6.4-22.04_edge
 
 peers:
   cluster:

--- a/src/literals.py
+++ b/src/literals.py
@@ -13,3 +13,8 @@ CHARM_USERS = ["super", "sync"]
 CERTS_REL_NAME = "certificates"
 JMX_PORT = 9998
 METRICS_PROVIDER_PORT = 7000
+
+CONF_PATH = "/etc/zookeeper"
+DATA_PATH = "/var/lib/zookeeper"
+LOGS_PATH = "/var/log/zookeeper"
+BINARIES_PATH = "/opt/zookeeper"

--- a/src/tls.py
+++ b/src/tls.py
@@ -22,7 +22,7 @@ from ops.framework import Object
 from ops.model import Relation, Unit
 from ops.pebble import ExecError
 
-from literals import PEER
+from literals import CONF_PATH, PEER
 from utils import generate_password, push
 
 logger = logging.getLogger(__name__)
@@ -297,7 +297,7 @@ class ZooKeeperTLS(Object):
         push(
             container=self.container,
             content=self.private_key,
-            path=f"{self.charm.zookeeper_config.default_config_path}/server.key",
+            path=f"{CONF_PATH}/server.key",
         )
 
     def set_ca(self) -> None:
@@ -309,7 +309,7 @@ class ZooKeeperTLS(Object):
         push(
             container=self.container,
             content=self.ca,
-            path=f"{self.charm.zookeeper_config.default_config_path}/ca.pem",
+            path=f"{CONF_PATH}/ca.pem",
         )
 
     def set_certificate(self) -> None:
@@ -321,7 +321,7 @@ class ZooKeeperTLS(Object):
         push(
             container=self.container,
             content=self.certificate,
-            path=f"{self.charm.zookeeper_config.default_config_path}/server.pem",
+            path=f"{CONF_PATH}/server.pem",
         )
 
     def set_truststore(self) -> None:
@@ -342,7 +342,7 @@ class ZooKeeperTLS(Object):
                     f"{self.keystore_password}",
                     "-noprompt",
                 ],
-                working_dir=self.charm.zookeeper_config.default_config_path,
+                working_dir=CONF_PATH,
             )
             logger.debug(str(proc.wait_output()[1]))
         except ExecError as e:
@@ -375,7 +375,7 @@ class ZooKeeperTLS(Object):
                     "-password",
                     f"pass:{self.keystore_password}",
                 ],
-                working_dir=self.charm.zookeeper_config.default_config_path,
+                working_dir=CONF_PATH,
             )
             logger.debug(str(proc.wait_output()[1]))
         except ExecError as e:
@@ -394,7 +394,7 @@ class ZooKeeperTLS(Object):
                     "*.p12",
                     "*.jks",
                 ],
-                working_dir=self.charm.zookeeper_config.default_config_path,
+                working_dir=CONF_PATH,
             )
         except ExecError as e:
             logger.error(e.stdout)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -122,7 +122,7 @@ async def ping_servers(ops_test: OpsTest) -> bool:
 
 def check_properties(model_full_name: str, unit: str):
     properties = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh --container zookeeper {unit} 'cat /opt/zookeeper/conf/zoo.cfg'",
+        f"JUJU_MODEL={model_full_name} juju ssh --container zookeeper {unit} 'cat /etc/zookeeper/zoo.cfg'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -132,7 +132,7 @@ def check_properties(model_full_name: str, unit: str):
 
 def check_jaas_config(model_full_name: str, unit: str):
     config = check_output(
-        f"JUJU_MODEL={model_full_name} juju ssh --container zookeeper {unit} 'cat /opt/zookeeper/conf/zookeeper-jaas.cfg'",
+        f"JUJU_MODEL={model_full_name} juju ssh --container zookeeper {unit} 'cat /etc/zookeeper/zookeeper-jaas.cfg'",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,7 +57,7 @@ def test_jmx_in_jvmflags(harness):
     opts = ZooKeeperConfig(harness.charm).jmx_jvmflags
     assert "-Dcom.sun.management.jmxremote" in opts
     assert (
-        "-javaagent:/opt/zookeeper/jmx_prometheus_javaagent.jar=9998:/opt/zookeeper/conf/jmx_prometheus.yaml"
+        "-javaagent:/opt/zookeeper/jmx_prometheus_javaagent.jar=9998:/etc/zookeeper/jmx_prometheus.yaml"
         in opts
     )
 


### PR DESCRIPTION
Blocked by https://github.com/canonical/zookeeper-rock/pull/15. Until it's merged, all tests will fail.

## Changes Made
##### `refactor: update data/logs/conf directory paths`
- Removed these options from `config.yaml`

##### `feat: use gchr image`