### PR TITLE
[DPE-1901] Bind pinned image revision

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   zookeeper-image:
     type: oci-image
     description: OCI Image for Apache ZooKeeper
-    upstream-source: ghcr.io/canonical/charmed-zookeeper:3-edge
+    upstream-source: ghcr.io/canonical/charmed-zookeeper@sha256:b7c0087798e291c038c28c3899f4a8985c291d23cd72bce2ab641f966b1f1421
 
 peers:
   cluster:


### PR DESCRIPTION
Addressing https://warthogs.atlassian.net/browse/DPE-1901

# Description

We want to bind each charm (Zookeeper, Kafka) on both substrate (K8s, VM) with pinned snap revision and rocks hashes.

Take inspiration from mysql 

* [VM](https://github.com/canonical/mysql-operator/blob/main/src/constants.py#L27)

* [K8s](https://github.com/canonical/mysql-k8s-operator/blob/main/metadata.yaml#L36)

# Acceptance Criteria

All charms are pinned to snap revision and rock hashes