### PR TITLE
DPE-2639 - test: add network cut test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -131,6 +131,7 @@ class ZooKeeperK8sCharm(CharmBase):
     @property
     def _zookeeper_layer(self) -> Layer:
         """Returns a Pebble configuration layer for ZooKeeper."""
+        unit_host = self.cluster.unit_config(unit=self.unit)["host"]
         layer_config: "LayerDict" = {
             "summary": "zookeeper layer",
             "description": "Pebble config layer for zookeeper",
@@ -146,6 +147,13 @@ class ZooKeeperK8sCharm(CharmBase):
                             + self.zookeeper_config.jmx_jvmflags
                         )
                     },
+                },
+            },
+            "checks": {
+                CONTAINER: {
+                    "override": "replace",
+                    "level": "alive",
+                    "exec": {"command": f"echo ruok | nc {unit_host} {self.cluster.client_port}"},
                 }
             },
         }

--- a/tests/integration/ha/conftest.py
+++ b/tests/integration/ha/conftest.py
@@ -1,0 +1,16 @@
+from collections.abc import AsyncGenerator
+
+import helpers
+import pytest
+from pytest_operator.plugin import OpsTest
+
+
+@pytest.fixture()
+async def chaos_mesh(ops_test: OpsTest) -> AsyncGenerator:
+    """Deploys chaos mesh to the namespace and uninstalls it at the end."""
+    helpers.deploy_chaos_mesh(ops_test.model.info.name)
+
+    yield
+
+    helpers.remove_instance_isolation(ops_test)
+    helpers.destroy_chaos_mesh(ops_test.model.info.name)

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -383,7 +383,7 @@ def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
     """
     with tempfile.NamedTemporaryFile() as temp_file:
         with open(
-            "tests/integration/ha/manifests/chaos_network_loss.yml", "r"
+            "tests/integration/ha/manifests/chaos_network_loss.yaml", "r"
         ) as chaos_network_loss_file:
             template = string.Template(chaos_network_loss_file.read())
             chaos_network_loss = template.substitute(

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -1,6 +1,9 @@
 import logging
+import os
 import re
+import string
 import subprocess
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -332,3 +335,84 @@ def check_key(host: str, password: str, username: str = USERNAME) -> None:
         return
 
     raise KeyError
+
+
+def deploy_chaos_mesh(namespace: str) -> None:
+    """Deploy chaos mesh to the provided namespace.
+
+    Args:
+        namespace: The namespace to deploy chaos mesh to
+    """
+    env = os.environ
+    env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
+
+    subprocess.check_output(
+        " ".join(
+            [
+                "tests/integration/ha/scripts/deploy_chaos_mesh.sh",
+                namespace,
+            ]
+        ),
+        shell=True,
+        env=env,
+    )
+
+
+def destroy_chaos_mesh(namespace: str) -> None:
+    """Remove chaos mesh from the provided namespace.
+
+    Args:
+        namespace: The namespace to deploy chaos mesh to
+    """
+    env = os.environ
+    env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
+
+    subprocess.check_output(
+        f"tests/integration/ha/scripts/destroy_chaos_mesh.sh {namespace}",
+        shell=True,
+        env=env,
+    )
+
+
+def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
+    """Apply a NetworkChaos file to use chaos-mesh to simulate a network cut.
+
+    Args:
+        ops_test: OpsTest
+        unit_name: the Juju unit running the ZooKeeper process
+    """
+    with tempfile.NamedTemporaryFile() as temp_file:
+        with open(
+            "tests/integration/ha/manifests/chaos_network_loss.yml", "r"
+        ) as chaos_network_loss_file:
+            template = string.Template(chaos_network_loss_file.read())
+            chaos_network_loss = template.substitute(
+                namespace=ops_test.model.info.name,
+                pod=unit_name.replace("/", "-"),
+            )
+
+            temp_file.write(str.encode(chaos_network_loss))
+            temp_file.flush()
+
+        env = os.environ
+        env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
+
+        subprocess.check_output(
+            " ".join(["kubectl", "apply", "-f", temp_file.name]), shell=True, env=env
+        )
+
+
+def remove_instance_isolation(ops_test: OpsTest) -> None:
+    """Delete the NetworkChaos that is isolating the primary unit of the cluster.
+
+    Args:
+        ops_test: OpsTest
+    """
+    env = os.environ
+    env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
+
+    subprocess.check_output(
+        f"kubectl -n {ops_test.model.info.name} delete --ignore-not-found=true networkchaos network-loss-primary",
+        shell=True,
+        env=env,
+    )

--- a/tests/integration/ha/manifests/chaos_network_loss.yaml
+++ b/tests/integration/ha/manifests/chaos_network_loss.yaml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-loss-primary
+  namespace: $namespace
+spec:
+  action: loss
+  mode: one
+  selector:
+    pods:
+      $namespace:
+        - $pod
+  loss:
+    loss: "100"
+    correlation: "100"
+  duration: "60m"

--- a/tests/integration/ha/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/ha/scripts/deploy_chaos_mesh.sh
@@ -12,10 +12,10 @@ fi
 
 deploy_chaos_mesh() {
 	echo "adding chaos-mesh helm repo"
-	sg snap_microk8s -c "microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org"
+	sg microk8s -c "microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org"
 
 	echo "installing chaos-mesh"
-        sg snap_microk8s -c "microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
+        sg microk8s -c "microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
           --namespace=\"${chaos_mesh_ns}\" \
           --set chaosDaemon.runtime=containerd \
           --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock \

--- a/tests/integration/ha/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/ha/scripts/deploy_chaos_mesh.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+chaos_mesh_ns=$1
+chaos_mesh_version="2.4.1"
+
+if [ -z "${chaos_mesh_ns}" ]; then
+	echo "Error: missing mandatory argument. Aborting" >&2
+	exit 1
+fi
+
+deploy_chaos_mesh() {
+	echo "adding chaos-mesh helm repo"
+	sg snap_microk8s -c "microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org"
+
+	echo "installing chaos-mesh"
+        sg snap_microk8s -c "microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
+          --namespace=\"${chaos_mesh_ns}\" \
+          --set chaosDaemon.runtime=containerd \
+          --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock \
+          --set dashboard.create=false \
+          --version \"${chaos_mesh_version}\" \
+          --set clusterScoped=false \
+          --set controllerManager.targetNamespace=\"${chaos_mesh_ns}\" \
+          "
+	sleep 10
+}
+
+echo "namespace=${chaos_mesh_ns}"
+deploy_chaos_mesh

--- a/tests/integration/ha/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/ha/scripts/destroy_chaos_mesh.sh
@@ -45,9 +45,9 @@ destroy_chaos_mesh() {
 		timeout 30 kubectl delete crd "${args[@]}" || true
 	fi
 
-	if [ -n "${chaos_mesh_ns}" ] && sg snap_microk8s -c "microk8s.helm3 repo list --namespace=${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
+	if [ -n "${chaos_mesh_ns}" ] && sg microk8s -c "microk8s.helm3 repo list --namespace=${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
 		echo "uninstalling chaos-mesh helm repo"
-		sg snap_microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=\"${chaos_mesh_ns}\"" || true
+		sg microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=\"${chaos_mesh_ns}\"" || true
 	fi
 }
 

--- a/tests/integration/ha/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/ha/scripts/destroy_chaos_mesh.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+chaos_mesh_ns=$1
+
+if [ -z "${chaos_mesh_ns}" ]; then
+	echo "Error: missing mandatory argument. Aborting" >&2
+	exit 1
+fi
+
+destroy_chaos_mesh() {
+	echo "deleting api-resources"
+	for i in $(kubectl api-resources | awk '/chaos-mesh/ {print $1}'); do
+	    timeout 30 kubectl delete "${i}" --all --all-namespaces || true
+	done
+
+	if kubectl -n "${chaos_mesh_ns}" get mutatingwebhookconfiguration | grep -q 'choas-mesh-mutation'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete mutatingwebhookconfiguration chaos-mesh-mutation || true
+	fi
+
+	if kubectl -n "${chaos_mesh_ns}" get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete validatingwebhookconfiguration chaos-mesh-validation || true
+	fi
+
+	if kubectl -n "${chaos_mesh_ns}" get validatingwebhookconfiguration | grep -q 'chaos-mesh-validate-auth'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete validatingwebhookconfiguration chaos-mesh-validate-auth || true
+	fi
+
+	if kubectl get clusterrolebinding | grep -q 'chaos-mesh'; then
+		echo "deleting clusterrolebindings"
+		readarray -t args < <(kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
+		timeout 30 kubectl delete clusterrolebinding "${args[@]}" || true
+	fi
+
+	if kubectl get clusterrole | grep -q 'chaos-mesh'; then
+		echo "deleting clusterroles"
+		readarray -t args < <(kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
+		timeout 30 kubectl delete clusterrole "${args[@]}" || true
+	fi
+
+	if kubectl get crd | grep -q 'chaos-mesh.org'; then
+		echo "deleting crds"
+		readarray -t args < <(kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
+		timeout 30 kubectl delete crd "${args[@]}" || true
+	fi
+
+	if [ -n "${chaos_mesh_ns}" ] && sg snap_microk8s -c "microk8s.helm3 repo list --namespace=${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
+		echo "uninstalling chaos-mesh helm repo"
+		sg snap_microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=\"${chaos_mesh_ns}\"" || true
+	fi
+}
+
+echo "Destroying chaos mesh in ${chaos_mesh_ns}"
+destroy_chaos_mesh

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -221,3 +221,124 @@ async def test_freeze_db_process(ops_test: OpsTest, request):
     )
     assert last_write == last_write_leader
     assert total_writes == total_writes_leader
+
+
+@pytest.mark.abort_on_fail
+async def test_two_clusters_not_replicated(ops_test: OpsTest, request):
+    """Confirms that writes to one cluster are not replicated to another."""
+    zk_2 = f"{helpers.APP_NAME}2"
+
+    logger.info("Deploying second cluster...")
+    new_charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(
+        new_charm,
+        application_name=zk_2,
+        num_units=3,
+        resources={"zookeeper-image": helpers.ZOOKEEPER_IMAGE},
+        series=helpers.SERIES,
+    )
+    await helpers.wait_idle(ops_test, apps=[helpers.APP_NAME, zk_2])
+
+    parent = request.node.name
+
+    hosts_1 = helpers.get_hosts(ops_test)
+    hosts_2 = helpers.get_hosts(ops_test, app_name=zk_2)
+    password_1 = helpers.get_super_password(ops_test)
+    password_2 = helpers.get_super_password(ops_test, app_name=zk_2)
+
+    logger.info("Starting continuous_writes on original cluster...")
+    cw.start_continuous_writes(
+        parent=parent, hosts=hosts_1, username=helpers.USERNAME, password=password_1
+    )
+    await asyncio.sleep(CLIENT_TIMEOUT * 3)  # letting client set up and start writing
+
+    logger.info("Checking writes are running at all...")
+    assert cw.count_znodes(
+        parent=parent, hosts=hosts_1, username=helpers.USERNAME, password=password_1
+    )
+
+    logger.info("Stopping continuous_writes...")
+    cw.stop_continuous_writes()
+
+    logger.info("Confirming writes on original cluster...")
+    assert cw.count_znodes(
+        parent=parent, hosts=hosts_1, username=helpers.USERNAME, password=password_1
+    )
+
+    logger.info("Confirming writes not replicated to new cluster...")
+    with pytest.raises(Exception):
+        cw.count_znodes(
+            parent=parent, hosts=hosts_2, username=helpers.USERNAME, password=password_2
+        )
+
+    logger.info("Cleaning up old cluster...")
+    await ops_test.model.applications[zk_2].remove()
+    await helpers.wait_idle(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_network_cut_without_ip_change(ops_test: OpsTest, request, chaos_mesh):
+    """Cuts and restores network on leader, cluster self-heals after IP change."""
+    hosts = helpers.get_hosts(ops_test)
+    leader_name = helpers.get_leader_name(ops_test, hosts)
+    initial_leader_host = helpers.get_unit_host(ops_test, leader_name)
+    password = helpers.get_super_password(ops_test)
+    parent = request.node.name
+    non_leader_hosts = ",".join([host for host in hosts.split(",") if host != initial_leader_host])
+
+    logger.info("Starting continuous_writes...")
+    cw.start_continuous_writes(
+        parent=parent, hosts=hosts, username=helpers.USERNAME, password=password
+    )
+    await asyncio.sleep(CLIENT_TIMEOUT * 3)  # letting client set up and start writing
+
+    logger.info("Checking writes are running at all...")
+    assert cw.count_znodes(
+        parent=parent, hosts=hosts, username=helpers.USERNAME, password=password
+    )
+
+    logger.info("Cutting leader network...")
+    helpers.isolate_instance_from_cluster(ops_test, leader_name)
+    await asyncio.sleep(CLIENT_TIMEOUT * 3)
+    logger.info("Checking writes are increasing...")
+    writes = cw.count_znodes(
+        parent=parent, hosts=non_leader_hosts, username=helpers.USERNAME, password=password
+    )
+    await asyncio.sleep(CLIENT_TIMEOUT * 3)  # increasing writes
+    new_writes = cw.count_znodes(
+        parent=parent, hosts=non_leader_hosts, username=helpers.USERNAME, password=password
+    )
+    assert new_writes > writes, "writes not continuing to ZK"
+
+    logger.info("Checking leader re-election...")
+    new_leader_name = helpers.get_leader_name(ops_test, non_leader_hosts)
+    assert new_leader_name != leader_name
+
+    logger.info("Restoring leader network...")
+    helpers.remove_instance_isolation(ops_test)
+
+    # livenessProbe should fail after 10*3 seconds by default, then the container is restarted
+    # allows dead ZK server to rejoin quorum
+    await asyncio.sleep(CLIENT_TIMEOUT * 6)
+
+    logger.info("Stopping continuous_writes...")
+    cw.stop_continuous_writes()
+
+    logger.info("Counting writes on surviving units...")
+    last_write = cw.get_last_znode(
+        parent=parent, hosts=non_leader_hosts, username=helpers.USERNAME, password=password
+    )
+    total_writes = cw.count_znodes(
+        parent=parent, hosts=non_leader_hosts, username=helpers.USERNAME, password=password
+    )
+    assert last_write == total_writes
+
+    logger.info("Checking old leader caught up...")
+    last_write_leader = cw.get_last_znode(
+        parent=parent, hosts=initial_leader_host, username=helpers.USERNAME, password=password
+    )
+    total_writes_leader = cw.count_znodes(
+        parent=parent, hosts=initial_leader_host, username=helpers.USERNAME, password=password
+    )
+    assert last_write == last_write_leader
+    assert total_writes == total_writes_leader


### PR DESCRIPTION
## Changes Made
#### `feat: ruok livenessProbe for container health`
- Uses the `ruok` 4lw command to ping the local ZooKeeper server
- Defaults to `period=10s` and `threshold=3` as per the [Pebble specification](https://github.com/canonical/pebble#layer-specification)
- If fails, container is restarted as per [K8s specification](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
#### `chore: add chaos mesh for network cut`
#### `test: add network cut ha test`