### PR TITLE
DPE-2710 - test: add storage scale down/up storage re-use test

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,6 +13,9 @@ maintainers:
 containers:
   zookeeper:
     resource: zookeeper-image
+    mounts:
+      - storage: zookeeper
+        location: /var/lib/zookeeper
 
 resources:
   zookeeper-image:
@@ -44,7 +47,7 @@ requires:
     optional: true
 
 storage:
-  data:
+  zookeeper:
     type: filesystem
     description: Directories where snapshot and transaction data is stored
     minimum-size: 10G

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -524,3 +524,34 @@ async def delete_pod(ops_test, unit_name: str) -> None:
     )
 
     await wait_idle(ops_test)
+
+
+def get_transaction_logs_and_snapshots(
+    ops_test, unit_name: str, container_name: str = CONTAINER
+) -> dict[str, list[str]]:
+    """Gets the most recent transaction log and snapshot files.
+
+    Args:
+        ops_test: OpsTest
+        unit_name: the Juju unit to get timestamps from
+        container_name: the container to run command on
+            Defaults to '{container_name}'
+
+    Returns:
+        Dict of keys "transactions", "snapshots" and value of list of filenames
+    """
+    transaction_files = subprocess.check_output(
+        f"kubectl exec {unit_name.replace('/', '-')} -c {container_name} -n {ops_test.model.info.name} -- ls -1 /var/lib/zookeeper/data-log/version-2",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    ).splitlines()
+
+    snapshot_files = subprocess.check_output(
+        f"kubectl exec {unit_name.replace('/', '-')} -c {container_name} -n {ops_test.model.info.name} -- ls -1 /var/lib/zookeeper/data/version-2",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    ).splitlines()
+
+    return {"transactions": transaction_files, "snapshots": snapshot_files}


### PR DESCRIPTION
## Changes Made
#### `fix: actually use storage, persist both transactions + snapshots`
- Storage volume was mounted to the `charm` container, not to the `workload`. As such, storage wasn't actually persisted
- Resolved by persisting `data` and `data-log` dirs under `/var/lib/zookeeper`
- Although advice is to mount transactions + snapshots on different volumes for IO performance, Juju supports only a single volume. As ZooKeeper uses the Txn log to re-build snapshots after data loss, it's a trade-off for now
#### `test: add scaling storage re-use test`
- Checks for existence of 'old' files after a scale-down + up
- If 'old' files present, storage was re-used