### PR TITLE
fix: properly remove old zNodes during relation-broken

### DIFF
--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -49,8 +49,11 @@ class ProviderEvents(Object):
             return
 
         # ACLs created before passwords set to avoid restarting before successful adding
+        # passing event here allows knowledge of broken app, removing it's chroot from ACL list
         try:
-            self.charm.quorum_manager.update_acls()
+            self.charm.quorum_manager.update_acls(
+                event=event if isinstance(event, RelationBrokenEvent) else None
+            )
         except (
             MembersSyncingError,
             MemberNotReadyError,

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -390,10 +390,10 @@ class ConfigManager:
         config_properties = self.static_properties
 
         properties_changed = set(server_properties) ^ set(config_properties)
-        logger.debug(f"{properties_changed=}")
 
-        jaas_config = self.current_jaas
-        jaas_changed = set(jaas_config) ^ set(self.jaas_config.splitlines())
+        clean_server_jaas = [conf.strip() for conf in self.current_jaas]
+        clean_config_jaas = [conf.strip() for conf in self.jaas_config.splitlines()]
+        jaas_changed = set(clean_server_jaas) ^ set(clean_config_jaas)
 
         log_level_changed = self.log_level not in "".join(self.current_env)
 
@@ -411,8 +411,6 @@ class ConfigManager:
             self.set_zookeeper_properties()
 
         if jaas_changed:
-            clean_server_jaas = [conf.strip() for conf in jaas_config]
-            clean_config_jaas = [conf.strip() for conf in self.jaas_config.splitlines()]
             logger.info(
                 (
                     f"Server.{self.state.unit_server.unit_id} updating JAAS config - "

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -99,7 +99,9 @@ async def test_deploy_multiple_charms_relate_active(ops_test: OpsTest):
 async def test_scale_up_gets_new_jaas_users(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].scale(scale=4)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 4)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active")
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", idle_period=30)
 
     assert ping_servers(ops_test)
     for unit in ops_test.model.applications[APP_NAME].units:

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -4,13 +4,14 @@
 
 import logging
 from pathlib import Path
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 import yaml
 from ops.testing import Harness
 
 from charm import ZooKeeperCharm
-from literals import CHARM_KEY
+from literals import CHARM_KEY, PEER, REL_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +23,10 @@ METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 @pytest.fixture
 def harness():
     harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
-    harness.add_relation("restart", CHARM_KEY)
     upgrade_rel_id = harness.add_relation("upgrade", CHARM_KEY)
+    harness.add_relation("restart", CHARM_KEY)
     harness.update_relation_data(upgrade_rel_id, f"{CHARM_KEY}/0", {"state": "idle"})
+    harness.add_relation(PEER, CHARM_KEY)
     harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
     harness.begin()
     return harness
@@ -57,3 +59,52 @@ def test_is_child_of_not(harness):
     chroots = {"/gandalf", "/saruman"}
 
     assert not harness.charm.quorum_manager._is_child_of(path=chroot, chroots=chroots)
+
+
+def test_update_acls_correctly_handles_relation_chroots(harness):
+    dummy_leader_znodes = {
+        "/fellowship",
+        "/fellowship/men",
+        "/fellowship/dwarves",
+        "/fellowship/men/aragorn",
+        "/fellowship/men/boromir",
+        "/fellowship/elves/legolas",
+        "/fellowship/dwarves/gimli",
+        "/fellowship/men/aragorn/anduril",
+    }
+
+    with harness.hooks_disabled():
+        app_id = harness.add_relation(REL_NAME, "application")
+        harness.update_relation_data(app_id, "application", {"chroot": "/rohan"})
+        harness.set_leader(True)
+
+    with patch.multiple(
+        "charms.zookeeper.v0.client.ZooKeeperManager",
+        get_leader=DEFAULT,
+        leader_znodes=MagicMock(return_value=dummy_leader_znodes),
+        create_znode_leader=DEFAULT,
+        set_acls_znode_leader=DEFAULT,
+        delete_znode_leader=DEFAULT,
+    ) as patched_manager:
+        harness.charm.quorum_manager.update_acls()
+
+        for _, kwargs in patched_manager["create_znode_leader"].call_args_list:
+            assert "/rohan" in kwargs["path"]
+
+        for _, kwargs in patched_manager["set_acls_znode_leader"].call_args_list:
+            assert "/rohan" in kwargs["path"]
+
+        removed_men = False
+        for counter, call in enumerate(patched_manager["delete_znode_leader"].call_args_list):
+            _, kwargs = call
+
+            if "/fellowship/men" in kwargs["path"]:
+                assert not removed_men, "Parent zNode removed before all it's children"
+
+            if kwargs["path"] == "/fellowship/men":
+                removed_men = True
+
+        # ensure last node to go is the parent
+        assert (
+            patched_manager["delete_znode_leader"].call_args_list[-1][1]["path"] == "/fellowship"
+        )


### PR DESCRIPTION
## Changes Made
#### `fix: properly remove old zNodes during relation-broken`
- Mistake from the refactor meant that on `relation-broken` events, the `chroot` from the broken Application would still exist, with it's zNodes surviving the break
- Removing a Kafka relation, then re-relating, would persist the original ACLs (e.g `relation-6`) on child nodes (e.g `/kafka/config/users`) sharing the same parent (e.g `/kafka`)
- This meant that the related application couldn't authenticate to the new zNodes