### PR TITLE
fix: skip relation-changed if upgrading

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -161,6 +161,12 @@ class ZooKeeperCharm(CharmBase):
             self._set_status(Status.NO_PEER_RELATION)
             return
 
+        # don't want to prematurely set config using outdated/missing relation data
+        # also skip update-status overriding statues during upgrades
+        if not self.upgrade_events.idle:
+            event.defer()
+            return
+
         # attempt startup of server
         if not self.state.unit_server.started:
             self.init_server()

--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -52,6 +52,8 @@ class ZKUpgradeEvents(DataUpgrade):
         if not self.charm.workload.alive or not self.charm.state.unit_server.started or self.idle:
             return
 
+        self.apply_backwards_compatibility_fixes()
+
         # useful to have a log here to indicate that the upgrade is progressing
         try:
             self.charm.workload.healthy
@@ -133,3 +135,7 @@ class ZKUpgradeEvents(DataUpgrade):
             else:
                 cause = str(e)
             raise KubernetesClientError("Kubernetes StatefulSet patch failed", cause)
+
+    def apply_backwards_compatibility_fixes(self) -> None:
+        """A range of functions needed for backwards compatibility."""
+        return

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ from tests.unit.test_charm import PropertyMock
 
 @pytest.fixture(autouse=True)
 def patched_idle(mocker):
-    mocker.patch(
+    yield mocker.patch(
         "events.upgrade.ZKUpgradeEvents.idle", new_callable=PropertyMock, return_value=True
     )
 

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -210,6 +210,7 @@ def test_upgrade_granted_succeeds(harness, mocker):
     mocker.patch.object(ZKUpgradeEvents, "pre_upgrade_check")
     mocker.patch.object(ZKUpgradeEvents, "set_unit_completed")
     mocker.patch.object(ZKUpgradeEvents, "set_unit_failed")
+    mocker.patch.object(ZKUpgradeEvents, "apply_backwards_compatibility_fixes")
 
     mock_event = mocker.MagicMock()
 
@@ -217,6 +218,7 @@ def test_upgrade_granted_succeeds(harness, mocker):
 
     ZKWorkload.stop.assert_called_once()
     ZKWorkload.install.assert_called_once()
+    ZKUpgradeEvents.apply_backwards_compatibility_fixes.assert_called_once()
     ZKWorkload.restart.assert_called_once()
     ZKUpgradeEvents.set_unit_completed.assert_called_once()
     ZKUpgradeEvents.set_unit_failed.assert_not_called()
@@ -301,6 +303,7 @@ def test_zookeeper_pebble_ready_upgrade_sets_completed(harness, mocker):
     mocker.patch.object(ZKUpgradeEvents, "idle", new_callable=PropertyMock, return_value=False)
     mocker.patch.object(ZKWorkload, "alive", new_callable=PropertyMock, return_value=True)
     mocker.patch.object(ZKWorkload, "healthy", new_callable=PropertyMock, return_value=True)
+    mocker.patch.object(ZKUpgradeEvents, "apply_backwards_compatibility_fixes")
     mocker.patch.object(ZKUpgradeEvents, "post_upgrade_check", return_value=None)
     mocker.patch.object(ZKUpgradeEvents, "set_unit_completed")
 
@@ -308,4 +311,5 @@ def test_zookeeper_pebble_ready_upgrade_sets_completed(harness, mocker):
 
     harness.charm.upgrade_events._on_zookeeper_pebble_ready_upgrade(mock_event)
 
+    ZKUpgradeEvents.apply_backwards_compatibility_fixes.assert_called_once()
     ZKUpgradeEvents.set_unit_completed.assert_called_once()


### PR DESCRIPTION
## Changes Made
#### `fix: centralise compatibility patches during upgrades`
- Moved to dedicated method

#### `fix: skip relation-changed if not idle`
- `config_changed` setting of config items is now skipped, avoiding issues with missing new relation-data items
- Juju status setting should now be skipped on `update-status`, meaning that the charm will stay `BlockedStatus` if upgrade failed