### PR TITLE
[DPE-3479] Update image and paths

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,7 +21,7 @@ resources:
   zookeeper-image:
     type: oci-image
     description: OCI Image for Apache ZooKeeper
-    upstream-source: ghcr.io/canonical/charmed-zookeeper@sha256:dbdbd8367bf6d813b9aae1e15a6c1743f909db7555a47995b6b5d259e87f2af1
+    upstream-source: ghcr.io/canonical/charmed-zookeeper@sha256:a7a004644f8bf7f397e4aeb5d94b618d3343b1ab5ceca12fd327c35edc288b71
 
 peers:
   cluster:

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -63,7 +63,7 @@ class ZKPaths:
 
         Used for scraping and exposing mBeans of a JMX target.
         """
-        return f"{self.binaries_path}/jmx_prometheus_javaagent.jar"
+        return f"{self.binaries_path}/lib/jmx_prometheus_javaagent.jar"
 
     @property
     def jmx_prometheus_config(self) -> str:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -4,17 +4,12 @@
 
 """Manager for for handling configuration building + writing."""
 import logging
-from typing import TYPE_CHECKING
 
 from ops.model import ConfigData
-from ops.pebble import Layer
-
-if TYPE_CHECKING:
-    from ops.pebble import LayerDict
 
 from core.cluster import SUBSTRATES, ClusterState
 from core.workload import WorkloadBase
-from literals import CLIENT_PORT, CONTAINER, JMX_PORT, METRICS_PROVIDER_PORT
+from literals import JMX_PORT, METRICS_PROVIDER_PORT
 
 logger = logging.getLogger(__name__)
 
@@ -85,38 +80,6 @@ class ConfigManager:
             return "WARN"
 
         return config_log_level
-
-    @property
-    def layer(self) -> Layer:
-        """Returns a Pebble configuration layer for ZooKeeper on K8s."""
-        if self.substrate != "k8s":
-            raise NotImplementedError
-
-        layer_config: "LayerDict" = {
-            "summary": "zookeeper layer",
-            "description": "Pebble config layer for zookeeper",
-            "services": {
-                CONTAINER: {
-                    "override": "replace",
-                    "summary": "zookeeper",
-                    "command": f"{self.workload.paths.binaries_path}/bin/zkServer.sh --config {self.workload.paths.conf_path} start-foreground",
-                    "startup": "enabled",
-                    "environment": {
-                        "SERVER_JVMFLAGS": " ".join(self.server_jvmflags + self.jmx_jvmflags)
-                    },
-                },
-            },
-            "checks": {
-                CONTAINER: {
-                    "override": "replace",
-                    "level": "alive",
-                    "exec": {
-                        "command": f"echo ruok | nc {self.state.unit_server.host} {CLIENT_PORT}"
-                    },
-                }
-            },
-        }
-        return Layer(layer_config)
 
     @property
     def server_jvmflags(self) -> list[str]:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -99,7 +99,7 @@ class ConfigManager:
                 CONTAINER: {
                     "override": "replace",
                     "summary": "zookeeper",
-                    "command": f"/bin/zkServer.sh --config {self.workload.paths.conf_path} start-foreground",
+                    "command": f"{self.workload.paths.binaries_path}/bin/zkServer.sh --config {self.workload.paths.conf_path} start-foreground",
                     "startup": "enabled",
                     "environment": {
                         "SERVER_JVMFLAGS": " ".join(self.server_jvmflags + self.jmx_jvmflags)


### PR DESCRIPTION
OCI image is now updated with correct bin and log paths. Addresses #68 

NOTE: moved pebble layer declaration to `charm.py` for two reasons:
1. Pebble layer definition is strictly tied to k8s charms, so I woudn't consider it common/shared code.
2. Changing layer is a k8s only task, being in `managers.config` any change would need to be backported to vm. Like the one on this PR.

Thoughts on this?