### PR TITLE
[DPE-3783] Add alive check in get_version

### DIFF
--- a/src/workload.py
+++ b/src/workload.py
@@ -120,6 +120,9 @@ class ZKWorkload(WorkloadBase):
 
     @override
     def get_version(self) -> str:
+        if not self.alive:
+            return ""
+
         if not self.healthy:
             return ""
 


### PR DESCRIPTION
The change introduced in #84 would make integration tests flaky, because pebble commands would be issued before the service was launched