### PR TITLE
[DPE-5206] Add DIGEST scheme ACL to znode created by zookeeper

### DIFF
--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -212,8 +212,6 @@ class QuorumManager:
                 credential=make_digest_acl_credential(client.username, client.password),
                 **acls,
             )
-            logger.info(f"{sasl_acl=}")
-            logger.info(f"{digest_acl=}")
 
             requested_acls.add(sasl_acl)
             requested_acls.add(digest_acl)

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -18,7 +18,7 @@ from charms.zookeeper.v0.client import (
 )
 from kazoo.exceptions import BadArgumentsError, ConnectionClosedError
 from kazoo.handlers.threading import KazooTimeoutError
-from kazoo.security import make_acl
+from kazoo.security import make_acl, make_digest_acl_credential
 from ops.charm import RelationEvent
 
 from core.cluster import ClusterState
@@ -198,18 +198,25 @@ class QuorumManager:
             if not client.database:
                 continue
 
-            generated_acl = make_acl(
-                scheme="sasl",
-                credential=client.username,
-                read="r" in client.extra_user_roles,
-                write="w" in client.extra_user_roles,
-                create="c" in client.extra_user_roles,
-                delete="d" in client.extra_user_roles,
-                admin="a" in client.extra_user_roles,
-            )
-            logger.info(f"{generated_acl=}")
+            acls = {
+                "read": "r" in client.extra_user_roles,
+                "write": "w" in client.extra_user_roles,
+                "create": "c" in client.extra_user_roles,
+                "delete": "d" in client.extra_user_roles,
+                "admin": "a" in client.extra_user_roles,
+            }
 
-            requested_acls.add(generated_acl)
+            sasl_acl = make_acl(scheme="sasl", credential=client.username, **acls)
+            digest_acl = make_acl(
+                scheme="digest",
+                credential=make_digest_acl_credential(client.username, client.password),
+                **acls,
+            )
+            logger.info(f"{sasl_acl=}")
+            logger.info(f"{digest_acl=}")
+
+            requested_acls.add(sasl_acl)
+            requested_acls.add(digest_acl)
 
             # FIXME: data-platform-libs should handle this when it's implemented
             if client.database:
@@ -221,11 +228,11 @@ class QuorumManager:
             # Looks for newly related applications not in config yet
             if client.database not in leader_chroots:
                 logger.info(f"CREATE CHROOT - {client.database}")
-                self.client.create_znode_leader(path=client.database, acls=[generated_acl])
+                self.client.create_znode_leader(path=client.database, acls=[sasl_acl, digest_acl])
 
             # Looks for existing related applications
             logger.info(f"UPDATE CHROOT - {client.database}")
-            self.client.set_acls_znode_leader(path=client.database, acls=[generated_acl])
+            self.client.set_acls_znode_leader(path=client.database, acls=[sasl_acl, digest_acl])
 
         # Looks for applications no longer in the relation but still in config
         for chroot in sorted(leader_chroots - requested_chroots, reverse=True):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -34,7 +34,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
             num_units=1,
             config={"ca-common-name": "zookeeper"},
             series=TLS_OPERATOR_SERIES,
-            revision=163, # FIXME: Unpin once the TLS is fixed on edge channel
+            revision=163,  # FIXME: Unpin once the TLS is fixed on edge channel
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -34,7 +34,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
             num_units=1,
             config={"ca-common-name": "zookeeper"},
             series=TLS_OPERATOR_SERIES,
-            revision=163,
+            revision=163, # FIXME: Unpin once the TLS is fixed on edge channel
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -34,6 +34,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
             num_units=1,
             config={"ca-common-name": "zookeeper"},
             series=TLS_OPERATOR_SERIES,
+            revision=163,
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -107,9 +107,17 @@ def test_update_acls_correctly_handles_relation_chroots(harness):
 
         for _, kwargs in patched_manager["create_znode_leader"].call_args_list:
             assert "/rohan" in kwargs["path"]
+            acls = kwargs["acls"]
+            assert len(acls) == 2
+            assert len([acl for acl in acls if acl.perms == 31 and acl.id.scheme == "sasl"]) != 0
+            assert len([acl for acl in acls if acl.perms == 31 and acl.id.scheme == "digest"]) != 0
 
         for _, kwargs in patched_manager["set_acls_znode_leader"].call_args_list:
             assert "/rohan" in kwargs["path"]
+            acls = kwargs["acls"]
+            assert len(acls) == 2
+            assert len([acl for acl in acls if acl.perms == 31 and acl.id.scheme == "sasl"]) != 0
+            assert len([acl for acl in acls if acl.perms == 31 and acl.id.scheme == "digest"]) != 0
 
         removed_men = False
         for counter, call in enumerate(patched_manager["delete_znode_leader"].call_args_list):

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ description = Run unit tests
 commands =
     poetry install --no-root --with unit
     poetry run coverage run --source={[vars]src_path} \
-        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit/test_quorum.py
+        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
 
 [testenv:integration-{charm,provider,password-rotation,tls,ha,replication}]

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ description = Run unit tests
 commands =
     poetry install --no-root --with unit
     poetry run coverage run --source={[vars]src_path} \
-        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
+        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit/test_quorum.py
     poetry run coverage report
 
 [testenv:integration-{charm,provider,password-rotation,tls,ha,replication}]


### PR DESCRIPTION
This PR adds an additional ACL with "DIGEST" scheme to the znodes created by zookeeper. This is needed because Kyuubi uses DIGEST ACL to create / write znodes and is not able to access the znodes created by zookeeper otherwise.