### PR TITLE
[DPE-3477] Reload stores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ name = "zookeeper-k8s-operator"
 version = "1.0"
 description = "zookeeper-k8s-operator"
 authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -111,10 +111,6 @@ class TLSEvents(Object):
             logger.error("Can't use certificate, found unknown CSR")
             return
 
-        # if certificate already exists, this event must be new, flag manual restart
-        if self.charm.state.unit_server.certificate:
-            self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
-
         self.charm.state.unit_server.update(
             {"certificate": event.certificate, "ca-cert": event.ca, "ca": ""}
         )

--- a/src/literals.py
+++ b/src/literals.py
@@ -25,6 +25,15 @@ ELECTION_PORT = 3888
 JMX_PORT = 9998
 METRICS_PROVIDER_PORT = 7000
 
+# Unused on k8s, here for compatibility reasons
+# '584788' refers to snap_daemon, which do not exists on the storage-attached hook prior to the
+# snap install.
+# FIXME (24.04): From snapd 2.61 onwards, snap_daemon is being deprecated and replaced with _daemon_,
+# which now possesses a UID of 584792.
+# See https://snapcraft.io/docs/system-usernames.
+USER = 584788
+GROUP = "root"
+
 S3_REL_NAME = "s3-credentials"
 S3_BACKUPS_PATH = "zookeeper_backups"
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -35,12 +35,12 @@ TLS_PROPERTIES = """
 secureClientPort=2182
 ssl.clientAuth=none
 ssl.quorum.clientAuth=none
-ssl.client.enable=true
 clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 ssl.trustStore.type=JKS
 ssl.keyStore.type=PKCS12
 sslQuorumReloadCertFiles=true
+client.certReload=true
 """
 
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -40,6 +40,7 @@ clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 ssl.trustStore.type=JKS
 ssl.keyStore.type=PKCS12
+sslQuorumReloadCertFiles=true
 """
 
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -10,6 +10,7 @@ import ops.pebble
 
 from core.cluster import SUBSTRATES, ClusterState
 from core.workload import WorkloadBase
+from literals import GROUP, USER
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class TLSManager:
 
             if self.substrate == "vm":
                 self.workload.exec(
-                    command=["chown", "snap_daemon:root", self.workload.paths.truststore],
+                    command=["chown", f"{USER}:{GROUP}", self.workload.paths.truststore],
                 )
         except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:
             if "already exists" in str(e.stdout):
@@ -68,7 +69,7 @@ class TLSManager:
                 try:
                     if self.substrate == "vm":
                         self.workload.exec(
-                            command=["chown", "root:root", self.workload.paths.truststore],
+                            command=["chown", f"{GROUP}:{GROUP}", self.workload.paths.truststore],
                         )
                     self._import_ca_in_truststore("ca-upcoming")
                     self._delete_ca_in_truststore("ca")
@@ -76,7 +77,7 @@ class TLSManager:
                     self._delete_ca_in_truststore("ca-upcoming")
                     if self.substrate == "vm":
                         self.workload.exec(
-                            command=["chown", "snap_daemon:root", self.workload.paths.truststore],
+                            command=["chown", f"{USER}:{GROUP}", self.workload.paths.truststore],
                         )
                 except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:
 
@@ -147,7 +148,7 @@ class TLSManager:
             )
             if self.substrate == "vm":
                 self.workload.exec(
-                    command=["chown", "snap_daemon:root", self.workload.paths.keystore],
+                    command=["chown", f"{USER}:{GROUP}", self.workload.paths.keystore],
                 )
 
         except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -52,36 +52,73 @@ class TLSManager:
 
     def set_truststore(self) -> None:
         """Creates the unit Java Truststore and adds the unit CA."""
-        keytool_cmd = "charmed-zookeeper.keytool" if self.substrate == "vm" else "keytool"
-
         try:
-            self.workload.exec(
-                command=[
-                    keytool_cmd,
-                    "-import",
-                    "-v",
-                    "-alias",
-                    "ca",
-                    "-file",
-                    self.workload.paths.ca,
-                    "-keystore",
-                    self.workload.paths.truststore,
-                    "-storepass",
-                    self.state.unit_server.truststore_password,
-                    "-noprompt",
-                ],
-            )
+            self._import_ca_in_truststore()
+
             if self.substrate == "vm":
                 self.workload.exec(
                     command=["chown", "snap_daemon:root", self.workload.paths.truststore],
                 )
-
         except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:
             if "already exists" in str(e.stdout):
+                # replace ca in four steps to prevent the truststore for being empty at any point.
+                try:
+                    if self.substrate == "vm":
+                        self.workload.exec(
+                            command=["chown", "root:root", self.workload.paths.truststore],
+                        )
+                    self._import_ca_in_truststore("ca-temp")
+                    self._delete_ca_in_truststore("ca")
+                    self._import_ca_in_truststore("ca")
+                    self._delete_ca_in_truststore("ca-temp")
+                    if self.substrate == "vm":
+                        self.workload.exec(
+                            command=["chown", "snap_daemon:root", self.workload.paths.truststore],
+                        )
+                except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:
+
+                    logger.error(str(e.stdout))
+                    raise e
+
                 return
 
             logger.error(str(e.stdout))
             raise e
+
+    def _import_ca_in_truststore(self, alias: str = "ca") -> None:
+        keytool_cmd = "charmed-zookeeper.keytool" if self.substrate == "vm" else "keytool"
+        self.workload.exec(
+            command=[
+                keytool_cmd,
+                "-import",
+                "-v",
+                "-alias",
+                alias,
+                "-file",
+                self.workload.paths.ca,
+                "-keystore",
+                self.workload.paths.truststore,
+                "-storepass",
+                self.state.unit_server.truststore_password,
+                "-noprompt",
+            ],
+        )
+
+    def _delete_ca_in_truststore(self, alias: str) -> None:
+        keytool_cmd = "charmed-zookeeper.keytool" if self.substrate == "vm" else "keytool"
+        self.workload.exec(
+            command=[
+                keytool_cmd,
+                "-delete",
+                "-v",
+                "-alias",
+                alias,
+                "-keystore",
+                self.workload.paths.truststore,
+                "-storepass",
+                self.state.unit_server.truststore_password,
+            ],
+        )
 
     def set_p12_keystore(self) -> None:
         """Creates the unit Java Keystore and adds unit certificate + private-key."""

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -61,16 +61,19 @@ class TLSManager:
                 )
         except (subprocess.CalledProcessError, ops.pebble.ExecError) as e:
             if "already exists" in str(e.stdout):
-                # replace ca in four steps to prevent the truststore for being empty at any point.
+                # Replacement strategy:
+                # - We need to own the file, otherwise keytool throws a permission error upon removing an entry
+                # - We need to make sure that the keystore is not empty at any point, hence the four steps.
+                #  Otherwise, ZK would pick up the file change when it's empty, and crash its internal watcher thread
                 try:
                     if self.substrate == "vm":
                         self.workload.exec(
                             command=["chown", "root:root", self.workload.paths.truststore],
                         )
-                    self._import_ca_in_truststore("ca-temp")
+                    self._import_ca_in_truststore("ca-upcoming")
                     self._delete_ca_in_truststore("ca")
                     self._import_ca_in_truststore("ca")
-                    self._delete_ca_in_truststore("ca-temp")
+                    self._delete_ca_in_truststore("ca-upcoming")
                     if self.substrate == "vm":
                         self.workload.exec(
                             command=["chown", "snap_daemon:root", self.workload.paths.truststore],

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+from subprocess import PIPE, check_output
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -151,9 +152,24 @@ async def test_pod_reschedule_tls(ops_test: OpsTest):
 async def test_renew_cert(ops_test: OpsTest):
     # invalidate previous certs
     await ops_test.model.applications[TLS_NAME].set_config({"ca-common-name": "new-name"})
-    async with ops_test.fast_forward(fast_interval="60s"):
-        await ops_test.model.wait_for_idle(
-            [APP_NAME], status="active", timeout=1000, idle_period=30
-        )
 
+    await ops_test.model.wait_for_idle([APP_NAME], status="active", timeout=1000, idle_period=30)
+    async with ops_test.fast_forward(fast_interval="20s"):
+        await asyncio.sleep(60)
+
+    # check quorum TLS
     assert ping_servers(ops_test)
+
+    # check client-presented certs
+    for unit in ops_test.model.applications[APP_NAME].units:
+        host = unit.public_address
+        break
+
+    response = check_output(
+        f"openssl s_client -showcerts -connect {host}:2182 < /dev/null",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    assert "CN = new-name" in response

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -145,3 +145,15 @@ async def test_pod_reschedule_tls(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(
             [APP_NAME], status="active", timeout=1000, idle_period=30
         )
+
+
+@pytest.mark.abort_on_fail
+async def test_renew_cert(ops_test: OpsTest):
+    # invalidate previous certs
+    await ops_test.model.applications[TLS_NAME].set_config({"ca-common-name": "new-name"})
+    async with ops_test.fast_forward(fast_interval="60s"):
+        await ops_test.model.wait_for_idle(
+            [APP_NAME], status="active", timeout=1000, idle_period=30
+        )
+
+    assert ping_servers(ops_test)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -161,7 +161,7 @@ async def test_renew_cert(ops_test: OpsTest):
     assert ping_servers(ops_test)
 
     # check client-presented certs
-    host = get_address(ops_test, unit_num=0)
+    host = await get_address(ops_test, unit_num=0)
 
     response = check_output(
         f"openssl s_client -showcerts -connect {host}:2182 < /dev/null",

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from . import APP_NAME, SERIES, TLS_OPERATOR_SERIES, ZOOKEEPER_IMAGE
-from .helpers import check_properties, delete_pod, ping_servers
+from .helpers import check_properties, delete_pod, get_address, ping_servers
 
 logger = logging.getLogger(__name__)
 
@@ -161,9 +161,7 @@ async def test_renew_cert(ops_test: OpsTest):
     assert ping_servers(ops_test)
 
     # check client-presented certs
-    for unit in ops_test.model.applications[APP_NAME].units:
-        host = unit.public_address
-        break
+    host = get_address(ops_test, unit_num=0)
 
     response = check_output(
         f"openssl s_client -showcerts -connect {host}:2182 < /dev/null",


### PR DESCRIPTION
## Changes

- Enable `sslQuorumReloadCertFiles` and `client.certReload` to dynamically reload the trust and key store for both quorum and client TLS. Removed restart event emission.
- Removed `ssl.client.enable` which is not a ZooKeeper configuration option.
- Replace stores content upon new certificate available. The code is a little too nested for my tastes, but IMO still understandable. I can always extract the innermost code into a `_replace_ca_in_truststore` method if needed
