### PR TITLE
[DPE-5208] - fix: enforce client auth

### DIFF
--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -369,7 +369,7 @@ class ZooKeeperManager:
 
         return all_znode_children
 
-    def create_znode_leader(self, path: str, acls: List[ACL]) -> None:
+    def create_znode_leader(self, path: str, acls: List[ACL] | None = None) -> None:
         """Creates a new zNode on the current quorum leader with given ACLs.
 
         Args:
@@ -388,7 +388,7 @@ class ZooKeeperManager:
         ) as zk:
             zk.create_znode(path=path, acls=acls)
 
-    def set_acls_znode_leader(self, path: str, acls: List[ACL]) -> None:
+    def set_acls_znode_leader(self, path: str, acls: List[ACL] | None = None) -> None:
         """Updates ACLs for an existing zNode on the current quorum leader.
 
         Args:
@@ -577,7 +577,7 @@ class ZooKeeperClient:
             return
         self.client.delete(path, recursive=True)
 
-    def create_znode(self, path: str, acls: List[ACL]) -> None:
+    def create_znode(self, path: str, acls: List[ACL] | None = None) -> None:
         """Create new znode.
 
         Args:
@@ -599,7 +599,7 @@ class ZooKeeperClient:
 
         return acl_list if acl_list else []
 
-    def set_acls(self, path: str, acls: List[ACL]) -> None:
+    def set_acls(self, path: str, acls: List[ACL] | None = None) -> None:
         """Sets acls for a desired znode path.
 
         Args:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -36,6 +36,8 @@ audit.enable=true
 
 TLS_PROPERTIES = """
 secureClientPort=2182
+ssl.clientAuth=none
+ssl.quorum.clientAuth=none
 clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 ssl.trustStore.type=JKS

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -28,13 +28,14 @@ quorum.auth.enableSasl=true
 quorum.auth.learnerRequireSasl=true
 quorum.auth.serverRequireSasl=true
 authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+enforce.auth.enabled=true
+enforce.auth.schemes=sasl
+sessionRequireClientSASLAuth=true
 audit.enable=true
 """
 
 TLS_PROPERTIES = """
 secureClientPort=2182
-ssl.clientAuth=none
-ssl.quorum.clientAuth=none
 clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 ssl.trustStore.type=JKS

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -191,7 +191,6 @@ class QuorumManager:
         leader_chroots = self.client.leader_znodes(path="/")
         logger.debug(f"{leader_chroots=}")
 
-        requested_acls = set()
         requested_chroots = set()
 
         for client in self.state.clients:
@@ -209,8 +208,6 @@ class QuorumManager:
             )
             logger.info(f"{generated_acl=}")
 
-            requested_acls.add(generated_acl)
-
             # FIXME: data-platform-libs should handle this when it's implemented
             if client.database:
                 if event and client.relation and client.relation.id == event.relation.id:
@@ -224,7 +221,7 @@ class QuorumManager:
                 self.client.create_znode_leader(path=client.database, acls=[generated_acl])
 
             # Looks for existing related applications
-            logger.info(f"UPDATE CHROOT - {client.database}")
+            logger.debug(f"UPDATE CHROOT - {client.database}")
             self.client.set_acls_znode_leader(path=client.database, acls=[generated_acl])
 
         # Looks for applications no longer in the relation but still in config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -132,14 +132,21 @@ def test_multiple_jaas_users_are_added(harness):
 def test_tls_enabled(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.state.peer_relation.id, CHARM_KEY, {"tls": "enabled"}
+            harness.charm.state.peer_relation.id,
+            CHARM_KEY,
+            {"tls": "enabled", "quorum": "ssl"},
+        )
+        harness.update_relation_data(
+            harness.charm.state.peer_relation.id,
+            f"{CHARM_KEY}/0",
+            {"certificate": "foo"},
         )
 
-    assert "ssl.client.enable=true" in harness.charm.config_manager.zookeeper_properties
+    assert "sslQuorum=true" in harness.charm.config_manager.zookeeper_properties
 
 
 def test_tls_disabled(harness):
-    assert "ssl.client.enable=true" not in harness.charm.config_manager.zookeeper_properties
+    assert "sslQuorum=true" not in harness.charm.config_manager.zookeeper_properties
 
 
 def test_tls_switching_encryption(harness):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -135,11 +135,11 @@ def test_tls_enabled(harness):
             harness.charm.state.peer_relation.id, CHARM_KEY, {"tls": "enabled"}
         )
 
-    assert "ssl.clientAuth=none" in harness.charm.config_manager.zookeeper_properties
+    assert "ssl.client.enable=true" in harness.charm.config_manager.zookeeper_properties
 
 
 def test_tls_disabled(harness):
-    assert "ssl.clientAuth=none" not in harness.charm.config_manager.zookeeper_properties
+    assert "ssl.client.enable=true" not in harness.charm.config_manager.zookeeper_properties
 
 
 def test_tls_switching_encryption(harness):


### PR DESCRIPTION
## Changes Made
#### `fix: enforce SASL client auth`
- Was a new feature in [ZooKeeper 3.7](https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html#sc_authOptions)