### PR TITLE
fix: failing upgrades without chain

### DIFF
--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -77,6 +77,9 @@ class TLSManager:
             logger.error(e.stdout)
             raise e
 
+        if not sans_lines:
+            return
+
         for line in sans_lines:
             if "DNS" in line and "IP" in line:
                 break

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -10,3 +10,5 @@ APP_NAME = METADATA["name"]
 ZOOKEEPER_IMAGE = METADATA["resources"]["zookeeper-image"]["upstream-source"]
 SERIES = "jammy"
 TLS_OPERATOR_SERIES = "jammy"
+TLS_NAME = "self-signed-certificates"
+MANUAL_TLS_NAME = "manual-tls-certificates"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -9,7 +9,7 @@ from subprocess import PIPE, check_output
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from . import APP_NAME, SERIES, TLS_OPERATOR_SERIES, ZOOKEEPER_IMAGE
+from . import APP_NAME, MANUAL_TLS_NAME, SERIES, TLS_NAME, TLS_OPERATOR_SERIES, ZOOKEEPER_IMAGE
 from .helpers import (
     check_properties,
     delete_pod,
@@ -20,9 +20,6 @@ from .helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-TLS_NAME = "self-signed-certificates"
-MANUAL_TLS_NAME = "manual-tls-certificates"
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
## Changes Made
#### `fix: failing upgrades without chain`
- Resolved by adding backwards compatibility fix
#### `test: upgrades with TLS`
#### `fix: get_current_sans raising if no SANs`
- Sometimes caused units to go in to error
