### PR TITLE
[Docs] Fix the docs build error for shallow clone 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,17 @@ build:
   tools:
     python: "3.11"
   jobs:
-    pre_install:
+    post_checkout:
     - git fetch --unshallow || true
+    # Cancel building pull requests when there aren't changed in the docs directory.
+    # If there are no changes (git diff exits with 0) we force the command to return with 183.
+    # This is a special exit code on Read the Docs that will cancel the build immediately.
+    # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+    - |
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'docs/' '.readthedocs.yaml';
+      then
+        exit 183;
+      fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,12 +144,23 @@ html_context = {
     "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
-    # "sequential_nav": "both",
+    "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
 
     # Required for feedback button    
     'github_issues': 'enabled',
+}
+
+# TODO: To enable the edit button on pages, uncomment and change the link to a
+# public repository on GitHub or Launchpad. Any of the following link domains
+# are accepted:
+# - https://github.com/example-org/example"
+# - https://launchpad.net/example
+# - https://git.launchpad.net/example
+
+html_theme_options = {
+'source_edit_link': 'https://github.com/canonical/zookeeper-k8s-operator',
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897

--- a/docs/content/how-to/index.md
+++ b/docs/content/how-to/index.md
@@ -3,7 +3,6 @@
 The following guides cover key processes and common tasks for managing and using Apache ZooKeeper K8s charm on machines:
 
 * How to deploy
-* How to enable monitoring
 
 ```{toctree}
 :hidden:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Apache ZooKeeper K8s charm is a distribution of Apache ZooKeeper. It’s an open
 
 - [Read our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
 - [Join the Discourse forum](https://discourse.charmhub.io/tag/kafka)
-- [Contribute](https://github.com/canonical/zookeeper-operator/blob/main/CONTRIBUTING.md) and report [issues](https://github.com/canonical/zookeeper-operator/issues/new)
+- [Contribute](https://github.com/canonical/zookeeper-k8s-operator/blob/main/CONTRIBUTING.md) and report [issues](https://https://github.com/canonical/zookeeper-k8s-operator/issues/new)
 - Explore [Canonical Data Fabric solutions](https://canonical.com/data)
 - [Contact us](https://discourse.charmhub.io/t/13107) for all further questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Apache ZooKeeper K8s charm is a distribution of Apache ZooKeeper. It’s an open
 
 - [Read our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
 - [Join the Discourse forum](https://discourse.charmhub.io/tag/kafka)
-- [Contribute](https://github.com/canonical/zookeeper-k8s-operator/blob/main/CONTRIBUTING.md) and report [issues](https://https://github.com/canonical/zookeeper-k8s-operator/issues/new)
+- [Contribute](https://github.com/canonical/zookeeper-k8s-operator/blob/main/CONTRIBUTING.md) and report [issues](https://github.com/canonical/zookeeper-k8s-operator/issues/new)
 - Explore [Canonical Data Fabric solutions](https://canonical.com/data)
 - [Contact us](https://discourse.charmhub.io/t/13107) for all further questions
 


### PR DESCRIPTION
ReadTheDocs config change to fix builds fail with warning messages for too shallow clone.