### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -45,10 +45,13 @@ peers:
 provides:
   zookeeper:
     interface: zookeeper
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
 
 requires:
   certificates:


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
